### PR TITLE
Performance toggle: pause DDGI / volumetric fog / post-process FX

### DIFF
--- a/index.html
+++ b/index.html
@@ -483,6 +483,18 @@
                             </details>
 
                             <details class="viewer-menu-section">
+                                <summary class="viewer-menu-section-summary">Performance</summary>
+                                <div class="viewer-menu-section-body">
+                                    <div class="viewer-inline-note">Turns off DDGI global illumination, volumetric fog, and post-process bloom for a fast-path render. Defaults stay unchanged — flip this when you need higher FPS in showcase or while authoring.</div>
+                                    <div class="viewer-toggle-group viewer-post-process-toggle-group">
+                                        <button class="btn viewer-toggle-btn viewer-toggle-btn-active" id="perf-mode-off">Off</button>
+                                        <button class="btn viewer-toggle-btn" id="perf-mode-on">On</button>
+                                    </div>
+                                    <div class="viewer-inline-note" id="perf-mode-status">Performance mode off. Full DDGI + fog + post-process active.</div>
+                                </div>
+                            </details>
+
+                            <details class="viewer-menu-section">
                                 <summary class="viewer-menu-section-summary">Multiplayer</summary>
                                 <div class="viewer-menu-section-body">
                                     <div class="viewer-input-stack">

--- a/main.js.perfmode.patch
+++ b/main.js.perfmode.patch
@@ -1,0 +1,112 @@
+--- a/main.js
++++ b/main.js
+@@ -421,6 +421,13 @@
+     bloomRadius: uniform(0.95),
+     bloomThreshold: uniform(0.48)
+ };
++
++// Performance toggle: when on, skips DDGI tick, volumetric fog update, and the
++// post-process volume update. The three subsystems own their own state via
++// setEnabled, so flipping this back to false restores the default render path
++// without a reload. Defaults to off — engine ships unchanged.
++let perfModeEnabled = false;
++let perfModeUiRefs = null;
+ let physicsCore;
+ let physicsRuntime;
+ let multiplayerController;
+@@ -3549,6 +3556,47 @@
+     return result;
+ }
+ 
++function updatePerfModeUi() {
++    if (!perfModeUiRefs) return;
++    perfModeUiRefs.offBtn?.classList.toggle('viewer-toggle-btn-active', !perfModeEnabled);
++    perfModeUiRefs.onBtn?.classList.toggle('viewer-toggle-btn-active', perfModeEnabled);
++    if (perfModeUiRefs.status) {
++        perfModeUiRefs.status.textContent = perfModeEnabled
++            ? 'Performance mode on. DDGI, volumetric fog, and post-process bloom are paused.'
++            : 'Performance mode off. Full DDGI + fog + post-process active.';
++    }
++}
++
++// Performance toggle: turn DDGI, volumetric fog, and post-process bloom off
++// (or on) at runtime without changing engine defaults. Each subsystem owns its
++// own enabled flag — we flip those here AND also gate the per-frame update
++// calls in the main render loop, so flipping this saves both render work and
++// CPU update work.
++function setPerfModeEnabled(isEnabled) {
++    const next = !!isEnabled;
++    if (perfModeEnabled === next) {
++        updatePerfModeUi();
++        return;
++    }
++    perfModeEnabled = next;
++
++    // Volumetric fog: hides the layer group AND clears scene.fog when off.
++    volumetricFogController?.setEnabled(!perfModeEnabled);
++
++    // DDGI: tick() short-circuits when state.enabled is false; injectionEnabled
++    // controls the shader-injection patching loop, which we also pause so
++    // newly-added materials don't get patched while perf mode is on.
++    const ddgi = getDDGIManager();
++    ddgi?.setEnabled(!perfModeEnabled);
++    ddgi?.setInjectionEnabled(!perfModeEnabled);
++
++    // Post-process: clamps bloom uniforms to neutral so the MRT bloom pass
++    // becomes a no-op while still running (cheap once strength is 0).
++    postProcessVolumeManager?.setEnabled(!perfModeEnabled);
++
++    updatePerfModeUi();
++}
++
+ function tickForceAllSceneMeshShadows() {
+     if (!shadowDebugState.forceAllMeshes && !gameplay.active) return;
+     if ((performance.now() - shadowDebugState.lastAppliedAt) < shadowDebugState.autoApplyIntervalMs) return;
+@@ -4151,6 +4199,11 @@
+         applyBtn: document.getElementById('debug-apply-mesh-shadows'),
+         status: document.getElementById('debug-shadow-status'),
+     };
++    perfModeUiRefs = {
++        offBtn: document.getElementById('perf-mode-off'),
++        onBtn: document.getElementById('perf-mode-on'),
++        status: document.getElementById('perf-mode-status'),
++    };
+ 
+     renderDebugConsoleOutput();
+     debugConsoleInput?.addEventListener('keydown', handleDebugConsoleInputKeydown);
+@@ -4215,6 +4268,14 @@
+         forceAllSceneMeshShadows();
+     });
+     updateShadowDebugUi();
++
++    perfModeUiRefs?.offBtn?.addEventListener('click', () => {
++        setPerfModeEnabled(false);
++    });
++    perfModeUiRefs?.onBtn?.addEventListener('click', () => {
++        setPerfModeEnabled(true);
++    });
++    updatePerfModeUi();
+ 
+     if (browseModelBtn) {
+         browseModelBtn.addEventListener('click', () => {
+@@ -4600,10 +4661,17 @@
+         }
+         updateVehicleVisuals(delta);
+         updateVehicleSurfaceEffects(delta);
+-        volumetricFogController?.update(delta);
+-        postProcessVolumeManager?.update(delta);
++        // Performance toggle: skip the per-frame work entirely when on.
++        // setPerfModeEnabled has already called setEnabled(false) on each subsystem
++        // so visuals stay flat; we just skip the update/tick CPU cost here.
++        if (!perfModeEnabled) {
++            volumetricFogController?.update(delta);
++            postProcessVolumeManager?.update(delta);
++        }
+         const _ddgiStart = performance.now();
+-        getDDGIManager().tick(delta);
++        if (!perfModeEnabled) {
++            getDDGIManager().tick(delta);
++        }
+         const _ddgiMs = performance.now() - _ddgiStart;
+         if (debugConsoleState?.latest) debugConsoleState.latest.ddgi = _ddgiMs;
+         tickForceAllSceneMeshShadows();

--- a/src/world/postProcessVolume.js
+++ b/src/world/postProcessVolume.js
@@ -8,6 +8,17 @@ const DEFAULT_POST_PROCESS_SETTINGS = {
     priority: 0,
 };
 
+// Settings used when the manager is force-disabled (Performance toggle).
+// Bloom strength of 0 effectively bypasses the bloom MRT pass; tone mapping
+// exposure stays neutral so the scene doesn't crush to black.
+const DISABLED_POST_PROCESS_SETTINGS = {
+    bloomStrength: 0.0,
+    bloomRadius: 0.0,
+    bloomThreshold: 1.0,
+    toneMappingExposure: 1.0,
+    priority: 0,
+};
+
 function clonePostProcessSettings(settings = {}) {
     return {
         bloomStrength: settings.bloomStrength ?? DEFAULT_POST_PROCESS_SETTINGS.bloomStrength,
@@ -45,6 +56,7 @@ export function createPostProcessVolumeManager({ scene, camera, renderer, global
         defaultSettings: clonePostProcessSettings(DEFAULT_POST_PROCESS_SETTINGS),
         debugVisible: false,
         editorVolume: null,
+        enabled: true,
     };
 
     state.group.name = 'post-process-volumes';
@@ -184,6 +196,13 @@ export function createPostProcessVolumeManager({ scene, camera, renderer, global
     function update(delta) {
         if (!camera) return;
 
+        // Performance toggle short-circuit: skip volume intersection + lerp work
+        // and clamp bloom uniforms to neutral so the post-process pass does no work.
+        if (!state.enabled) {
+            applyResolvedSettings(DISABLED_POST_PROCESS_SETTINGS);
+            return;
+        }
+
         const target = resolveTargetSettings();
         state.targetSettings = clonePostProcessSettings(target);
 
@@ -195,6 +214,17 @@ export function createPostProcessVolumeManager({ scene, camera, renderer, global
         state.currentSettings.toneMappingExposure = THREE.MathUtils.lerp(state.currentSettings.toneMappingExposure, target.toneMappingExposure, t);
 
         applyResolvedSettings(state.currentSettings);
+    }
+
+    function setEnabled(enabled) {
+        const next = !!enabled;
+        if (state.enabled === next) return;
+        state.enabled = next;
+        if (!next) {
+            // Apply neutral settings immediately so the disable is visible this frame
+            // without waiting for the lerp.
+            applyResolvedSettings(DISABLED_POST_PROCESS_SETTINGS);
+        }
     }
 
     return {
@@ -210,6 +240,8 @@ export function createPostProcessVolumeManager({ scene, camera, renderer, global
         },
         setTransitionSpeed,
         setDebugVisible,
+        setEnabled,
+        isEnabled: () => state.enabled,
         getSnapshot,
     };
 }


### PR DESCRIPTION
## What

Adds a **Performance** toggle to the right-side menu (under `Open tools`). When on:

- DDGI probe-update + integrate ticks are paused (`ddgiManager.setEnabled(false)` + `setInjectionEnabled(false)`).
- Volumetric fog stops updating and `scene.fog` is cleared (`volumetricFog.setEnabled(false)`).
- Post-process bloom uniforms are clamped to neutral (`bloomStrength=0`, `toneMappingExposure=1.0`) so the MRT bloom pass becomes a no-op.

**Defaults stay unchanged** — toggle ships off, full DDGI + fog + bloom are still active by default. Users flip it for showcase free-fly perf or while authoring.

Motivated by 24.9 FPS / 40.5 ms in the showcase scene (screenshot in the issue).

## Why this shape

Each subsystem already owned its enabled state (`volumetricFog.setEnabled`, `ddgi.setEnabled`). The only gap was post-process, where I added matching `setEnabled` + `isEnabled` methods. Then a single `perfModeEnabled` flag in `main.js` flips all three together and gates the per-frame update calls so we save CPU time too.

## Commits in this PR

1. `postProcessVolume.js`: add `setEnabled`/`isEnabled` + `DISABLED_POST_PROCESS_SETTINGS` constant.
2. `index.html`: add Performance `<details>` section after Debug Shadows with Off/On toggle buttons matching the existing pattern.

## ⚠️ main.js wiring not yet committed

The `main.js` change (~50 lines, sandbox tooling can't push the 256 KB file in a single commit — see context below) is included as a unified diff at the bottom of this body. Apply with `git apply` after pulling this branch, or ping me to push it.

## Quick test plan

- [ ] Open `Menu Sections › Performance`, click `On` — fog visibly disappears, scene gets brighter (no bloom), GI flat-shaded.
- [ ] Click `Off` — fog/bloom/GI return.
- [ ] Stat unit panel: confirm frame time drops while On.
- [ ] No reload required between toggles.

## main.js patch

```diff
--- a/main.js
+++ b/main.js
@@ -421,6 +421,13 @@
     bloomRadius: uniform(0.95),
     bloomThreshold: uniform(0.48)
 };
+
+// Performance toggle: when on, skips DDGI tick, volumetric fog update, and the
+// post-process volume update. The three subsystems own their own state via
+// setEnabled, so flipping this back to false restores the default render path
+// without a reload. Defaults to off — engine ships unchanged.
+let perfModeEnabled = false;
+let perfModeUiRefs = null;
 let physicsCore;
 let physicsRuntime;
 let multiplayerController;
@@ -3549,6 +3556,47 @@
     return result;
 }
 
+function updatePerfModeUi() {
+    if (!perfModeUiRefs) return;
+    perfModeUiRefs.offBtn?.classList.toggle('viewer-toggle-btn-active', !perfModeEnabled);
+    perfModeUiRefs.onBtn?.classList.toggle('viewer-toggle-btn-active', perfModeEnabled);
+    if (perfModeUiRefs.status) {
+        perfModeUiRefs.status.textContent = perfModeEnabled
+            ? 'Performance mode on. DDGI, volumetric fog, and post-process bloom are paused.'
+            : 'Performance mode off. Full DDGI + fog + post-process active.';
+    }
+}
+
+// Performance toggle: turn DDGI, volumetric fog, and post-process bloom off
+// (or on) at runtime without changing engine defaults. Each subsystem owns its
+// own enabled flag — we flip those here AND also gate the per-frame update
+// calls in the main render loop, so flipping this saves both render work and
+// CPU update work.
+function setPerfModeEnabled(isEnabled) {
+    const next = !!isEnabled;
+    if (perfModeEnabled === next) {
+        updatePerfModeUi();
+        return;
+    }
+    perfModeEnabled = next;
+
+    // Volumetric fog: hides the layer group AND clears scene.fog when off.
+    volumetricFogController?.setEnabled(!perfModeEnabled);
+
+    // DDGI: tick() short-circuits when state.enabled is false; injectionEnabled
+    // controls the shader-injection patching loop, which we also pause so
+    // newly-added materials don't get patched while perf mode is on.
+    const ddgi = getDDGIManager();
+    ddgi?.setEnabled(!perfModeEnabled);
+    ddgi?.setInjectionEnabled(!perfModeEnabled);
+
+    // Post-process: clamps bloom uniforms to neutral so the MRT bloom pass
+    // becomes a no-op while still running (cheap once strength is 0).
+    postProcessVolumeManager?.setEnabled(!perfModeEnabled);
+
+    updatePerfModeUi();
+}
+
 function tickForceAllSceneMeshShadows() {
     if (!shadowDebugState.forceAllMeshes && !gameplay.active) return;
     if ((performance.now() - shadowDebugState.lastAppliedAt) < shadowDebugState.autoApplyIntervalMs) return;
@@ -4151,6 +4199,11 @@
         applyBtn: document.getElementById('debug-apply-mesh-shadows'),
         status: document.getElementById('debug-shadow-status'),
     };
+    perfModeUiRefs = {
+        offBtn: document.getElementById('perf-mode-off'),
+        onBtn: document.getElementById('perf-mode-on'),
+        status: document.getElementById('perf-mode-status'),
+    };
 
     renderDebugConsoleOutput();
     debugConsoleInput?.addEventListener('keydown', handleDebugConsoleInputKeydown);
@@ -4215,6 +4268,14 @@
         forceAllSceneMeshShadows();
     });
     updateShadowDebugUi();
+
+    perfModeUiRefs?.offBtn?.addEventListener('click', () => {
+        setPerfModeEnabled(false);
+    });
+    perfModeUiRefs?.onBtn?.addEventListener('click', () => {
+        setPerfModeEnabled(true);
+    });
+    updatePerfModeUi();
 
     if (browseModelBtn) {
         browseModelBtn.addEventListener('click', () => {
@@ -4600,10 +4661,17 @@
         }
         updateVehicleVisuals(delta);
         updateVehicleSurfaceEffects(delta);
-        volumetricFogController?.update(delta);
-        postProcessVolumeManager?.update(delta);
+        // Performance toggle: skip the per-frame work entirely when on.
+        // setPerfModeEnabled has already called setEnabled(false) on each subsystem
+        // so visuals stay flat; we just skip the update/tick CPU cost here.
+        if (!perfModeEnabled) {
+            volumetricFogController?.update(delta);
+            postProcessVolumeManager?.update(delta);
+        }
         const _ddgiStart = performance.now();
-        getDDGIManager().tick(delta);
+        if (!perfModeEnabled) {
+            getDDGIManager().tick(delta);
+        }
         const _ddgiMs = performance.now() - _ddgiStart;
         if (debugConsoleState?.latest) debugConsoleState.latest.ddgi = _ddgiMs;
         tickForceAllSceneMeshShadows();
```

_To apply locally:_ `git fetch origin perf/performance-mode-toggle && git checkout perf/performance-mode-toggle && curl -L https://gist.githubusercontent.com/... > main.diff && git apply main.diff` — or just paste the diff above into a `main.diff` file and run `git apply main.diff`.
