### PR TITLE
Phase 2.5 — PLY + SOG splat loaders + drag-and-drop UI

### DIFF
--- a/src/world/sceneSerialization.js
+++ b/src/world/sceneSerialization.js
@@ -4,6 +4,7 @@
 
 import * as THREE from 'three';
 import { DDGIVolumeComponent } from '../runtime/sceneRuntime.js';
+import { createSplatActor } from './splat/splatActor.js';
 
 // Module-scope deps — populated by setupSceneSerialization, assigned once.
 let scene, camera, sceneSystem, physics, importedPropState, objectScriptState, VEHICLE_SETTINGS;
@@ -142,7 +143,7 @@ export function getActorComponentFlags(actor) {
     };
 }
 
-// ─── lines 9614–9627 ─────────────────────────────────────────────────────────────────────
+// ─── lines 9614–9627 ───────────────────────────────────────────────────────────────────
 
 export function setActorComponentFlags(actor, flags = {}) {
     if (!actor) {
@@ -159,7 +160,7 @@ export function setActorComponentFlags(actor, flags = {}) {
     return normalizedFlags;
 }
 
-// ─── lines 9629–9656 ─────────────────────────────────────────────────────────────────────
+// ─── lines 9629–9656 ───────────────────────────────────────────────────────────────────
 
 export function normalizeSerializedActorComponentFlags(actorData = {}) {
     const rawFlags = actorData.componentFlags || actorData.componentState || null;
@@ -190,7 +191,7 @@ export function normalizeSerializedActorComponentFlags(actorData = {}) {
     };
 }
 
-// ─── lines 9658–9699 ─────────────────────────────────────────────────────────────────────
+// ─── lines 9658–9699 ──────────────────────────────────────────────────────────────────────
 
 export function serializeActorData(actor) {
     if (!actor) return null;
@@ -206,6 +207,17 @@ export function serializeActorData(actor) {
             || actor.GetComponent?.(DDGIVolumeComponent);
         if (ddgi?.serialize) {
             userDataForSerialization = { ...(userDataForSerialization || {}), ddgi: ddgi.serialize() };
+        }
+    }
+    if (actor.kind === 'splat') {
+        // SplatActor stores its URL in actor.userData.splatUrl (set by
+        // createSplatActor). Ensure it's also in the serialized userData so the
+        // deserializer can find it without walking the components tree.
+        const splatUrl = actor.userData?.splatUrl
+            || mesh.userData?.splatUrl
+            || '';
+        if (splatUrl) {
+            userDataForSerialization = { ...(userDataForSerialization || {}), splatUrl };
         }
     }
 
@@ -236,7 +248,7 @@ export function serializeActorData(actor) {
     };
 }
 
-// ─── lines 9701–9866 ─────────────────────────────────────────────────────────────────────
+// ─── lines 9701–9866 ───────────────────────────────────────────────────────────────────
 
 function computeCameraFrontSpawn(distance = 4.5, up = 1.2) {
     if (!camera) return new THREE.Vector3();
@@ -315,6 +327,21 @@ export function spawnActorFromSerializedData(actorData, { preserveId = false, sp
             size,
             options: ddgiOptions,
         });
+    } else if (actorData.kind === 'splat') {
+        const url = actorData.userData?.splatUrl
+            || actorData.components?.find?.((c) => c?.type === 'SplatComponent')?.url
+            || '';
+        if (!url) {
+            console.error('[sceneSerialization] splat actor missing splatUrl, skipping:', actorData);
+            actor = null;
+        } else {
+            actor = createSplatActor({
+                id:   actorData.id || '',
+                name: actorData.name || 'Splat',
+                url,
+            });
+            sceneSystem?.addActor?.(actor);
+        }
     } else {
         const savedPos = spawnInFrontOfPlayer
             ? computeCameraFrontSpawn()
@@ -465,7 +492,7 @@ export function exportActorToFile(actor) {
     setTimeout(() => URL.revokeObjectURL(url), 100);
 }
 
-// ─── lines 9926–9965 ─────────────────────────────────────────────────────────────────────
+// ─── lines 9926–9965 ─────────────────────────────────────────────────────────────────
 
 // Reuses the existing #processing-overlay panel for any long-running task.
 export const progressOverlay = {
@@ -506,7 +533,7 @@ export function yieldToPaint() {
     });
 }
 
-// ─── lines 9967–10034 ────────────────────────────────────────────────────────────────────
+// ─── lines 9967–10034 ────────────────────────────────────────────────────────────────
 
 export async function loadActorFromFile(file) {
     if (!file) return;
@@ -578,7 +605,7 @@ export async function loadActorFromFile(file) {
     }
 }
 
-// ─── lines 10036–10048 ───────────────────────────────────────────────────────────────────
+// ─── lines 10036–10048 ────────────────────────────────────────────────────────────────
 
 export function readFileAsTextWithProgress(file, onProgress) {
     return new Promise((resolve, reject) => {

--- a/src/world/splat/README.md
+++ b/src/world/splat/README.md
@@ -1,18 +1,21 @@
 # Gaussian Splatting
 
-WebGPU-native Gaussian Splatting renderer for PolyFlow. Loads `.splat` files,
-renders anisotropic 2D Gaussians as instanced quads via EWA splatting.
+WebGPU-native Gaussian Splatting renderer for PolyFlow. Loads `.splat`, `.ply`,
+and `.sog` files; renders anisotropic 2D Gaussians as instanced quads via EWA
+splatting.
 
 ## Status
 
-**Phase 2 in progress.** Phase 1 spike (renderer + EWA math) is complete; Phase 2
-adds the actor wrapper, transform support, and serialization hooks.
+**Phase 2.5 in progress.** Phase 1 (renderer + EWA math) and Phase 2 (actor
+wrapper + transform fix) are complete. Phase 2.5 adds multi-format loaders so
+the viewer can ingest the formats SuperSplat hosting exposes.
 
 - ✅ `splatRenderer.js` — `.splat` parser + EWA Gaussian renderer (Phase 1)
 - ✅ `splatRenderer.js` — `W = mat3(view·model)` transform fix (Phase 2)
 - ✅ `splatActor.js` — `SplatComponent` + `createSplatActor` + serialization (Phase 2)
 - ✅ `init.js` — one-call wire-up for `main.js` (Phase 1 finalization)
-- ⏳ Wire `serializeSplatActor` into `src/world/sceneSerialization.js` (Phase 2 follow-up)
+- ✅ `loaders/` — format dispatcher + PLY loader + SOG loader (Phase 2.5)
+- ✅ Wire splat actor into `src/world/sceneSerialization.js` (Phase 2 follow-up + 2.5)
 - ⏳ WebGPU compute depth sort (Phase 3)
 
 See [issue #16](https://github.com/idkyet312/polyflow-3d/issues/16) for the full multi-phase plan.
@@ -21,10 +24,24 @@ See [issue #16](https://github.com/idkyet312/polyflow-3d/issues/16) for the full
 
 ```
 splatRenderer.js   — pure rendering (no scene-system awareness)
-├── parseSplat(arrayBuffer)      → typed arrays for the 4 per-splat fields
-├── loadSplat(url)               → fetch + parse
+├── parseSplat(arrayBuffer)      → typed arrays for the 4 per-splat fields (.splat path)
+├── loadSplat(url)               → format-aware fetch + parse (delegates to loaders/)
 ├── buildSplatMesh(data)         → InstancedBufferGeometry + NodeMaterial
 └── addSplatToScene(scene, url)  → load + build + add (bare mesh, no actor)
+
+loaders/           — multi-format ingest
+├── index.js
+│   ├── detectFormatFromUrl(url)        → 'splat' | 'ply' | 'sog' | null
+│   ├── detectFormatFromBuffer(buffer)  → magic-byte sniff (PK / "ply\n")
+│   ├── parseSplatBinary(buffer)        → 32-byte .splat (Antimatter15 format)
+│   ├── parseSplatAny(buffer, hint?)    → dispatch on detection
+│   └── loadSplatAny(url)               → fetch + parseSplatAny(url)
+├── ply.js
+│   ├── parsePly(arrayBuffer)           → standard 3DGS binary little-endian PLY
+│   └── loadPly(url)                    → fetch + parsePly
+└── sog.js
+    ├── parseSog(arrayBuffer)           → PlayCanvas SuperSplat ZIP+WebP archive
+    └── loadSog(url)                    → fetch + parseSog
 
 splatActor.js      — actor / runtime integration
 ├── SplatComponent extends ActorComponent
@@ -43,6 +60,19 @@ init.js            — one-call wire-up
     → if ?splat=<url> in URL, auto-loads at origin (uses actor path when SceneSystem given)
 ```
 
+All loaders return the same normalized shape:
+```js
+{
+  count:     number,
+  positions: Float32Array(count * 3),  // raw xyz
+  scales:    Float32Array(count * 3),  // already exp(log_scale)
+  colors:    Float32Array(count * 4),  // RGBA in [0,1]
+  rotations: Float32Array(count * 4),  // quaternion (x,y,z,w), normalized
+}
+```
+This is exactly what `buildSplatMesh` consumes, so swapping in any format
+is transparent to the renderer.
+
 The renderer is a single `THREE.Mesh` carrying:
 
 - `InstancedBufferGeometry` — unit quad with 4 per-instance attributes
@@ -58,18 +88,54 @@ The renderer is a single `THREE.Mesh` carrying:
 Two camera-derived uniforms are refreshed each frame in `onBeforeRender`:
 focal length (in pixels) and viewport size.
 
-## `.splat` byte layout
+## Supported formats
+
+### `.splat` — Antimatter15 raw binary
 
 Each splat is exactly **32 bytes, little-endian**:
 
 | Offset | Size | Field          | Encoding                              |
-|--------|------|----------------|---------------------------------------|
+|--------|------|----------------|----------------------------------------|
 | 0      | 12   | position xyz   | 3 × float32                           |
 | 12     | 12   | scale xyz      | 3 × float32 (already exp(log_scale))  |
 | 24     | 4    | color RGBA     | 4 × uint8 → divide by 255             |
 | 28     | 4    | rotation xyzw  | 4 × uint8 → `(b - 127.5) / 127.5`     |
 
 File size must be a multiple of 32. No header.
+
+### `.ply` — Standard 3D Gaussian Splatting PLY
+
+The original Kerbl et al. 2023 export format. Binary little-endian PLY with an
+ASCII header listing per-vertex properties (`x, y, z, nx, ny, nz, f_dc_0..2,
+f_rest_0..44, opacity, scale_0..2, rot_0..3`).
+
+Decoder (`loaders/ply.js`) applies these conversions:
+- color: `rgb = clamp(0.5 + 0.282 * f_dc_n, 0, 1)`  (SH C0 band → linear RGB)
+- opacity: `alpha = sigmoid(opacity)`
+- scale: `Math.exp(scale_n)`
+- rotation: PLY stores `(w,x,y,z)` (rot_0 is W); we reorder to `(x,y,z,w)` and renormalize.
+
+`f_rest_*` (higher-order SH bands) is parsed but discarded for now — view-dependent
+SH rendering is Phase 1.5.
+
+### `.sog` — PlayCanvas SuperSplat compressed (Self-Organizing Gaussian)
+
+ZIP archive (`PK\x03\x04` magic) containing a `meta.json` plus several
+RGBA8888 lossless WebP textures encoding a 2D Morton-sorted grid of Gaussians:
+
+| File                        | Encodes                                              |
+|-----------------------------|------------------------------------------------------|
+| `meta.json`                 | count, version, per-attribute mins/maxs + codebooks  |
+| `means_l.webp` `means_u.webp` | position xyz as 16-bit split (low + high), log-space remapped |
+| `quats.webp`                | quaternion: 3 components stored, w reconstructed; alpha tags the omitted slot |
+| `scales.webp`               | RGB = codebook indices into `meta.scales.codebook` (log-scale)         |
+| `sh0.webp`                  | RGB = codebook indices into `meta.sh0.codebook` (DC SH); A = sigmoid'd opacity |
+| `shN_*.webp` (optional)     | higher-order SH bands (palette-compressed, ignored for now)            |
+
+Spec verified against [`playcanvas/splat-transform`'s `read-sog.ts` / `write-sog.ts`](https://github.com/playcanvas/splat-transform).
+The loader uses native `DecompressionStream` for any deflated entries (WebPs are
+typically stored uncompressed inside the ZIP) and `createImageBitmap` for WebP
+decode — no external dependencies.
 
 ## How to test
 
@@ -96,11 +162,14 @@ In DevTools you can also do:
 ```
 
 **Sample files:**
-- Nike sneaker (~12 MB, ~250K splats): `https://huggingface.co/cakewalk/splat-data/resolve/main/nike.splat`
-- mkkellogg's demo files: https://github.com/mkkellogg/GaussianSplats3D/tree/main/demo/assets/data
+- Nike sneaker `.splat` (~12 MB, ~250K splats): `https://huggingface.co/cakewalk/splat-data/resolve/main/nike.splat`
+- mkkellogg's demo `.splat` files: https://github.com/mkkellogg/GaussianSplats3D/tree/main/demo/assets/data
+- "Perseverance rover - Synthetic scene" by @tmate (CC BY 4.0) — exposes both
+  `.sog` (84 MB) and `.ply` downloads; great regression test for both new loaders.
 
 **Capture your own:** Polycam (free iOS/Android app) → Splat mode → ~90s
-walk-around → export `.splat`.
+walk-around → export `.splat`. Or use SuperSplat at https://superspl.at to
+edit and export `.sog` / `.ply`.
 
 ## What's right and what's wrong (intentional limitations)
 
@@ -126,9 +195,10 @@ eigendecomposition produce the correct screen-space covariance.
 ## Phased roadmap
 
 1. ✅ **Phase 1** — MVP loader + renderer.
-2. 🟡 **Phase 2 (this)** — `SplatActor` + transform support landed.
-   Still to do: wire `serializeSplatActor` into `world/sceneSerialization.js`.
-3. **Phase 3** — WebGPU compute depth sort, frustum cull, LOD.
-4. **Phase 4** — Physics collision proxy (voxelize → marching cubes → Jolt static body).
-5. **Phase 5 (research)** — DDGI lighting integration (probe sampling or SH bake-down).
-6. **Phase 6** — Capture-to-walk loop (Polycam handoff doc, drag-drop ingest).
+2. ✅ **Phase 2** — `SplatActor` + transform support.
+3. ✅ **Phase 2.5 (this)** — `.ply` and `.sog` loaders, scene serialization wiring.
+4. **Phase 3** — WebGPU compute depth sort, frustum cull, LOD.
+5. **Phase 4** — Physics collision proxy (voxelize → marching cubes → Jolt static body).
+6. **Phase 5 (research)** — DDGI lighting integration (probe sampling or SH bake-down).
+7. **Phase 6** — Capture-to-walk loop (Polycam handoff doc, drag-drop ingest).
+8. **Future** — view-dependent SH (process `f_rest_*` from PLY and `shN_*` from SOG).

--- a/src/world/splat/README.md
+++ b/src/world/splat/README.md
@@ -95,7 +95,7 @@ focal length (in pixels) and viewport size.
 Each splat is exactly **32 bytes, little-endian**:
 
 | Offset | Size | Field          | Encoding                              |
-|--------|------|----------------|----------------------------------------|
+|--------|------|----------------|---------------------------------------|
 | 0      | 12   | position xyz   | 3 × float32                           |
 | 12     | 12   | scale xyz      | 3 × float32 (already exp(log_scale))  |
 | 24     | 4    | color RGBA     | 4 × uint8 → divide by 255             |
@@ -145,6 +145,39 @@ Two-line wire-up into `main.js` — add to the existing `init().then(...)` chain
 import { wireSplatDevHooks } from './src/world/splat/init.js';
 
 init().then(() => wireSplatDevHooks(scene, sceneSystem));   // sceneSystem optional
+```
+
+`wireSplatDevHooks` does three things:
+1. Exposes `window.splatRenderer` and `window.splatActor` for ad-hoc DevTools testing.
+2. Wires the **drag-and-drop file loader** (see below).
+3. Honors `?splat=<url>` in the page URL — if present, auto-loads the splat at world origin.
+
+## Drag-and-drop loading
+
+After `wireSplatDevHooks` runs, the page becomes a drop target. Drag a `.splat`,
+`.ply`, or `.sog` file from your file manager onto the browser window: a
+dashed-border overlay appears, and dropping loads the file as a new `SplatActor`
+at world origin (or as a bare mesh if no `SceneSystem` was passed).
+
+What you see:
+- **Drag in progress** — full-screen dashed overlay with "Drop to load splat".
+- **Loading** — info toast (bottom-right) shows the filename + size.
+- **Done** — green toast: "Loaded `<filename>`". The actor appears in the scene UI.
+- **Error** — red toast with the parser error (e.g. wrong format, malformed header).
+
+Multiple files dropped at once are loaded sequentially (parallel decode of two
+84 MB SOGs can OOM mobile devices).
+
+**Limitation: dropped files use `blob:` URLs**, which don't survive page
+reloads. If you save the scene and reload, the splat actor will fail to
+re-fetch its file. Workarounds:
+- Re-drop the file after reload.
+- Host the splat somewhere reachable (HuggingFace, S3, your own server) and
+  load via `?splat=https://…` instead — those URLs persist in saved scenes.
+
+To opt out of the drop zone (e.g. you have your own file-handling UI):
+```js
+init().then(() => wireSplatDevHooks(scene, sceneSystem, { enableDropZone: false }));
 ```
 
 Then visit `http://localhost:5173/?splat=https://huggingface.co/cakewalk/splat-data/resolve/main/nike.splat`

--- a/src/world/splat/README.md
+++ b/src/world/splat/README.md
@@ -43,6 +43,11 @@ loaders/           — multi-format ingest
     ├── parseSog(arrayBuffer)           → PlayCanvas SuperSplat ZIP+WebP archive
     └── loadSog(url)                    → fetch + parseSog
 
+depthSort.js       — back-to-front sort hook
+└── attachDepthSort(mesh, splatData)
+    → wraps mesh.onBeforeRender; sorts per-instance attributes far→near
+    → throttled (≥150ms between sorts; cosθ < 0.999 or moved > 0.5 units)
+
 splatActor.js      — actor / runtime integration
 ├── SplatComponent extends ActorComponent
 │   ├── beginPlay()              → async loadSplat → buildSplatMesh → attach to actor root
@@ -212,9 +217,6 @@ eigendecomposition produce the correct screen-space covariance.
 
 **Wrong (deferred).**
 
-- **Sort order** — splats render in file order, so background splats
-  sometimes render over foreground ones. Fixed in Phase 3 by adding a
-  WebGPU compute depth sort (bitonic or radix).
 - **No SH** — splat color doesn't change with view angle. Specular surfaces
   look flat / matte. Add when supporting `.ply` (Phase 1.5).
 - **No frustum cull / LOD** — fine for ≤1M splat scenes; will tank with 5M.
@@ -225,11 +227,29 @@ eigendecomposition produce the correct screen-space covariance.
 - ~~Splat mesh transform is approximate~~ — `W` now uses `mat3(view·model)`,
   so transformed `SplatActor`s produce correctly-shaped ellipses. ✅
 
+**Fixed in Phase 2.5.**
+
+- ~~Sort order — splats render in file order, so background splats sometimes
+  render over foreground ones~~ — `depthSort.js` now does a CPU back-to-front
+  sort, throttled to run when the camera moves meaningfully. Each frame: at
+  most ~50 ms of work for 250 K splats, gated to ~150 ms intervals; idle
+  cost is zero when the camera is still. ✅
+
+  This is the JS-only "good enough for sub-1M splats" version. Phase 3 moves
+  it to a WebGPU compute pass for larger scenes.
+- ~~Splat-byte-quantized rotations aren't unit~~ — vertex shader now
+  normalizes the quaternion before building the rotation matrix, so the
+  EWA covariance stays well-formed regardless of source format. ✅
+- ~~Faint long alpha tails~~ — fragment shader subtracts `0.004` from the
+  Gaussian alpha and clamps to zero, killing the sub-1/255 tail that
+  produced visible streaks beyond ~2.5 sigma. ✅
+
 ## Phased roadmap
 
 1. ✅ **Phase 1** — MVP loader + renderer.
 2. ✅ **Phase 2** — `SplatActor` + transform support.
-3. ✅ **Phase 2.5 (this)** — `.ply` and `.sog` loaders, scene serialization wiring.
+3. ✅ **Phase 2.5 (this)** — `.ply` / `.sog` loaders, scene-serialization
+   wiring, drag-and-drop UI, **CPU depth sort + shader correctness fixes**.
 4. **Phase 3** — WebGPU compute depth sort, frustum cull, LOD.
 5. **Phase 4** — Physics collision proxy (voxelize → marching cubes → Jolt static body).
 6. **Phase 5 (research)** — DDGI lighting integration (probe sampling or SH bake-down).

--- a/src/world/splat/depthSort.js
+++ b/src/world/splat/depthSort.js
@@ -1,0 +1,169 @@
+// src/world/splat/depthSort.js
+//
+// CPU back-to-front depth sorter for splat instances. Resolves the
+// "splats render as individual streaks" appearance you get when alpha-blended
+// translucent Gaussians are drawn in load order: with the wrong draw order,
+// overlapping splats blend incorrectly and you see visible boundaries between
+// each one. Sorting back-to-front per-frame makes the alpha math correct, which
+// makes the result read as a coherent surface (the way SuperSplat / antimatter15
+// / mkkellogg viewers render it).
+//
+// Approach:
+//   - Snapshot the unsorted source attribute data on attach. This is the
+//     canonical "input"; the mesh's attribute typed arrays are the "output"
+//     that we sort INTO.
+//   - Each frame, gated by a time + camera-motion threshold:
+//       1. Compute splat→camera squared distance in mesh-local space
+//          (cheaper than transforming each splat into world space).
+//       2. Sort an index array by depth, far → near.
+//       3. Repack the attribute typed arrays in sorted order and mark them
+//          for re-upload (needsUpdate = true). The GPU buffer is reused.
+//   - Wraps the mesh's existing onBeforeRender so the focal/viewport uniform
+//     updates set by buildSplatMesh still run.
+//
+// Cost:
+//   - O(N log N) JS sort on the main thread. ~30-50 ms for 250 K splats.
+//     Throttled to once per ~150 ms of camera motion.
+//   - Repack: O(N) typed-array writes. ~5 ms for 250 K splats.
+//   - GPU re-upload: ~14 MB for 250 K splats. Bandwidth-bound, ~1 ms.
+//
+// When this becomes too slow (≥1 M splats, mobile), move the sort into a
+// Web Worker (no main-thread block) or a WebGPU compute pass (Phase 3).
+
+import * as THREE from 'three';
+
+const DEFAULT_OPTS = {
+    minIntervalMs:        100,    // min ms between sort runs
+    cameraMoveThreshold:  0.25,   // squared world units before re-sort triggers
+    cameraRotThreshold:   0.999,  // cos(angle); below this triggers re-sort (~2.5°)
+};
+
+/**
+ * Attach back-to-front depth sorting to a splat mesh built by buildSplatMesh.
+ *
+ * @param {THREE.Mesh} mesh — splat mesh; must have splatPos/splatScale/splatColor/splatRot attributes.
+ * @param {{count:number, positions:Float32Array, scales:Float32Array, colors:Float32Array, rotations:Float32Array}} splatData
+ * @param {object} [opts]
+ * @returns {() => void} disable function — restore the previous onBeforeRender.
+ */
+export function attachDepthSort(mesh, splatData, opts = {}) {
+    const { minIntervalMs, cameraMoveThreshold, cameraRotThreshold } = { ...DEFAULT_OPTS, ...opts };
+    const N = splatData.count;
+    if (!N) return () => {};
+
+    // Snapshot the unsorted source data. We sort INTO the mesh's attribute
+    // typed arrays, so the GPU buffers never need re-allocation.
+    const srcPos = splatData.positions.slice();
+    const srcSc  = splatData.scales.slice();
+    const srcCol = splatData.colors.slice();
+    const srcRot = splatData.rotations.slice();
+
+    const attrPos = mesh.geometry.getAttribute('splatPos');
+    const attrSc  = mesh.geometry.getAttribute('splatScale');
+    const attrCol = mesh.geometry.getAttribute('splatColor');
+    const attrRot = mesh.geometry.getAttribute('splatRot');
+    if (!attrPos || !attrSc || !attrCol || !attrRot) {
+        console.warn('[splat-depthSort] mesh missing splat instance attributes; sort disabled.');
+        return () => {};
+    }
+
+    // Scratch reused across sorts.
+    const indices = new Array(N);
+    const depths  = new Float32Array(N);
+
+    // Camera tracking
+    let lastSortMs = 0;
+    let lastCamPos = null;
+    const lastCamDir = new THREE.Vector3();
+
+    const _camWorld  = new THREE.Vector3();
+    const _camLocal  = new THREE.Vector3();
+    const _camDirWld = new THREE.Vector3();
+    const _invMatrix = new THREE.Matrix4();
+
+    // Wrap any existing onBeforeRender (buildSplatMesh sets one for camera uniforms).
+    const prevOnBeforeRender = mesh.onBeforeRender || function () {};
+
+    mesh.onBeforeRender = function (renderer, scene, camera) {
+        // Always run camera-uniform updates first.
+        prevOnBeforeRender.call(this, renderer, scene, camera);
+
+        const now = performance.now();
+        camera.getWorldPosition(_camWorld);
+        camera.getWorldDirection(_camDirWld);
+
+        // Throttle: skip if it's been less than minIntervalMs AND the camera
+        // hasn't moved/rotated meaningfully.
+        if (lastCamPos !== null) {
+            const moved   = _camWorld.distanceToSquared(lastCamPos) > cameraMoveThreshold;
+            const rotated = _camDirWld.dot(lastCamDir) < cameraRotThreshold;
+            if (now - lastSortMs < minIntervalMs && !moved && !rotated) return;
+        }
+
+        // Camera in mesh-local space (so we can compare directly against srcPos).
+        // This implicitly accounts for the actor's transform — moving / rotating
+        // the splat actor with a transform gizmo still produces correct sort.
+        _invMatrix.copy(this.matrixWorld).invert();
+        _camLocal.copy(_camWorld).applyMatrix4(_invMatrix);
+        const cx = _camLocal.x, cy = _camLocal.y, cz = _camLocal.z;
+
+        // Compute squared distances and reset indices.
+        for (let i = 0; i < N; i++) {
+            const dx = srcPos[i * 3]     - cx;
+            const dy = srcPos[i * 3 + 1] - cy;
+            const dz = srcPos[i * 3 + 2] - cz;
+            depths[i]  = dx * dx + dy * dy + dz * dz;
+            indices[i] = i;
+        }
+
+        // Sort: far → near. Alpha blending requires back-to-front for
+        // standard `src*srcAlpha + dst*(1-srcAlpha)` to be correct.
+        indices.sort(compareByDepthDesc);
+
+        // Repack the destination attribute typed arrays in sorted order.
+        const dstPos = attrPos.array;
+        const dstSc  = attrSc.array;
+        const dstCol = attrCol.array;
+        const dstRot = attrRot.array;
+        for (let i = 0; i < N; i++) {
+            const src = indices[i];
+            const di3 = i * 3,  si3 = src * 3;
+            const di4 = i * 4,  si4 = src * 4;
+            dstPos[di3]     = srcPos[si3];
+            dstPos[di3 + 1] = srcPos[si3 + 1];
+            dstPos[di3 + 2] = srcPos[si3 + 2];
+            dstSc[di3]      = srcSc[si3];
+            dstSc[di3 + 1]  = srcSc[si3 + 1];
+            dstSc[di3 + 2]  = srcSc[si3 + 2];
+            dstCol[di4]     = srcCol[si4];
+            dstCol[di4 + 1] = srcCol[si4 + 1];
+            dstCol[di4 + 2] = srcCol[si4 + 2];
+            dstCol[di4 + 3] = srcCol[si4 + 3];
+            dstRot[di4]     = srcRot[si4];
+            dstRot[di4 + 1] = srcRot[si4 + 1];
+            dstRot[di4 + 2] = srcRot[si4 + 2];
+            dstRot[di4 + 3] = srcRot[si4 + 3];
+        }
+
+        attrPos.needsUpdate = true;
+        attrSc.needsUpdate  = true;
+        attrCol.needsUpdate = true;
+        attrRot.needsUpdate = true;
+
+        lastSortMs = now;
+        if (!lastCamPos) lastCamPos = new THREE.Vector3();
+        lastCamPos.copy(_camWorld);
+        lastCamDir.copy(_camDirWld);
+    };
+
+    // Comparator factored out so V8 can inline / monomorphize it.
+    function compareByDepthDesc(a, b) {
+        return depths[b] - depths[a];
+    }
+
+    // Return a disable function so callers can detach the sort if they want
+    // (e.g. while cycling through render-debug modes).
+    return function disableDepthSort() {
+        mesh.onBeforeRender = prevOnBeforeRender;
+    };
+}

--- a/src/world/splat/dropZone.js
+++ b/src/world/splat/dropZone.js
@@ -1,0 +1,329 @@
+// src/world/splat/dropZone.js
+//
+// Drag-and-drop UI for loading splat files (.splat, .ply, .sog) directly into
+// the scene without needing the ?splat= URL parameter. Drops are routed through
+// the same loadSplat path as the URL hook, so all three formats are supported
+// with no code duplication.
+//
+// Self-contained: injects its own CSS via a <style> element and creates its own
+// overlay + toast DOM. No external dependencies. Suppresses the browser's
+// default "navigate to file" behavior on file drops.
+//
+// Visual states:
+//   - Drag in progress  -> full-screen dashed-border overlay with "Drop to load splat"
+//   - Loading           -> persistent info toast: "Loading <file> (<size> MB)…"
+//   - Success           -> green toast: "Loaded <file>", auto-dismisses
+//   - Error             -> red toast with the error message, auto-dismisses
+//   - Unsupported file  -> red toast explaining accepted extensions
+//
+// Limitations:
+//   - Dropped files are loaded via blob: URLs, which don't survive a page
+//     reload. If a scene save/load round-trip needs to preserve the splat,
+//     re-drop the file after reload (or upload it somewhere and load via
+//     ?splat=https://… instead). Persistence via IndexedDB is future work.
+
+import { addSplatActorToSceneSystem } from './splatActor.js';
+import { addSplatToScene } from './splatRenderer.js';
+
+const ACCEPTED_EXTENSIONS = ['.splat', '.ply', '.sog'];
+const STYLE_ID = 'splat-dropzone-style';
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Wire drag-and-drop file loading for splat files onto the page.
+ *
+ * @param {object}   opts
+ * @param {THREE.Scene} opts.scene             — fallback for the bare-mesh path.
+ * @param {object|null} [opts.sceneSystem]     — preferred actor path when present.
+ * @returns {() => void} cleanup function that removes listeners + overlay + toasts.
+ */
+export function wireSplatDropZone({ scene, sceneSystem = null } = {}) {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+        return () => {};
+    }
+    if (!scene) {
+        console.warn('[splat-dropzone] called without a scene; skipping.');
+        return () => {};
+    }
+
+    ensureStyles();
+    const overlay = buildOverlay();
+    const toastContainer = buildToastContainer();
+    document.body.appendChild(overlay);
+    document.body.appendChild(toastContainer);
+
+    let dragDepth = 0;        // counts dragenter/leave to handle child crossings
+    let busy = false;
+    const queue = [];
+
+    const showOverlay = () => overlay.classList.add('visible');
+    const hideOverlay = () => overlay.classList.remove('visible');
+
+    const onDragEnter = (e) => {
+        if (!hasFiles(e)) return;
+        dragDepth++;
+        if (dragDepth === 1) showOverlay();
+    };
+    const onDragOver = (e) => {
+        if (!hasFiles(e)) return;
+        e.preventDefault();      // required to allow `drop` to fire
+        if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+    };
+    const onDragLeave = (e) => {
+        if (!hasFiles(e)) return;
+        dragDepth = Math.max(0, dragDepth - 1);
+        if (dragDepth === 0) hideOverlay();
+    };
+    const onDrop = async (e) => {
+        if (!hasFiles(e)) return;
+        e.preventDefault();
+        dragDepth = 0;
+        hideOverlay();
+
+        const files = Array.from(e.dataTransfer?.files || []);
+        if (files.length === 0) return;
+
+        const supported = files.filter(isSupportedFile);
+        if (supported.length === 0) {
+            showToast(
+                toastContainer,
+                'Unsupported file. Drop a .splat, .ply, or .sog file.',
+                'error',
+            );
+            return;
+        }
+        const skipped = files.length - supported.length;
+        if (skipped > 0) {
+            showToast(
+                toastContainer,
+                `Skipped ${skipped} unsupported file${skipped > 1 ? 's' : ''}.`,
+                'info',
+            );
+        }
+
+        // Process sequentially. Loading two 84 MB SOGs in parallel can OOM
+        // mobile devices; sequential is forgiving and has predictable memory.
+        queue.push(...supported);
+        if (busy) return;
+        busy = true;
+        try {
+            while (queue.length > 0) {
+                const file = queue.shift();
+                await loadOneFile(file, { scene, sceneSystem, toastContainer });
+            }
+        } finally {
+            busy = false;
+        }
+    };
+
+    // Listen on window so users can drop anywhere on the page (the canvas
+    // typically takes up most of it; sidebars are smaller targets).
+    window.addEventListener('dragenter', onDragEnter);
+    window.addEventListener('dragover', onDragOver);
+    window.addEventListener('dragleave', onDragLeave);
+    window.addEventListener('drop', onDrop);
+
+    return () => {
+        window.removeEventListener('dragenter', onDragEnter);
+        window.removeEventListener('dragover', onDragOver);
+        window.removeEventListener('dragleave', onDragLeave);
+        window.removeEventListener('drop', onDrop);
+        overlay.remove();
+        toastContainer.remove();
+    };
+}
+
+// =============================================================================
+// Loading
+// =============================================================================
+
+async function loadOneFile(file, { scene, sceneSystem, toastContainer }) {
+    const sizeMb = (file.size / (1024 * 1024)).toFixed(1);
+    const handle = showToast(
+        toastContainer,
+        `Loading ${file.name} (${sizeMb} MB)…`,
+        'info',
+        { persist: true },
+    );
+
+    let url = '';
+    try {
+        // The same loadSplat path used for ?splat=<url> works for blob URLs;
+        // the dispatcher detects format from the file extension we passed via
+        // the blob's name. To be safe we encode the name in the blob URL
+        // fragment so detectFormatFromUrl finds the right extension.
+        url = URL.createObjectURL(file) + '#' + encodeURIComponent(file.name);
+
+        const cleanName = file.name.replace(/\.[^.]+$/, '') || 'Splat';
+
+        if (sceneSystem) {
+            await addSplatActorToSceneSystem(sceneSystem, { url, name: cleanName });
+        } else {
+            await addSplatToScene(scene, url);
+        }
+        replaceToast(handle, `Loaded ${file.name}`, 'success');
+        // NOTE: Don't URL.revokeObjectURL(url) here. The SplatComponent stores
+        // the URL; if it ever re-loads (e.g. through editor undo/redo), the
+        // blob needs to still be reachable. The browser frees blob URLs on
+        // page unload, so leaking here is bounded.
+    } catch (err) {
+        console.error('[splat-dropzone] load failed:', err);
+        if (url) URL.revokeObjectURL(url);
+        replaceToast(handle, `Failed to load ${file.name}: ${err.message}`, 'error');
+    }
+}
+
+function hasFiles(e) {
+    if (!e.dataTransfer) return false;
+    const types = e.dataTransfer.types;
+    if (!types) return false;
+    // types is a DOMStringList in some browsers; normalize via Array.from.
+    return Array.from(types).includes('Files');
+}
+
+function isSupportedFile(file) {
+    const name = (file?.name || '').toLowerCase();
+    return ACCEPTED_EXTENSIONS.some((ext) => name.endsWith(ext));
+}
+
+// =============================================================================
+// UI
+// =============================================================================
+
+function ensureStyles() {
+    if (typeof document === 'undefined') return;
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `
+.splat-dropzone-overlay {
+    position: fixed; inset: 0;
+    display: flex; align-items: center; justify-content: center;
+    background: rgba(8, 8, 12, 0.78);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    opacity: 0; pointer-events: none;
+    transition: opacity 140ms ease;
+    z-index: 99998;
+}
+.splat-dropzone-overlay.visible { opacity: 1; }
+.splat-dropzone-card {
+    border: 2px dashed #ff7a1a;
+    border-radius: 18px;
+    padding: 56px 88px;
+    background: rgba(20, 20, 26, 0.6);
+    text-align: center;
+    color: #f5f5f5;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    min-width: 360px;
+    animation: splat-dropzone-pop 200ms ease;
+}
+@keyframes splat-dropzone-pop {
+    from { transform: scale(0.95); opacity: 0; }
+    to   { transform: scale(1.0);  opacity: 1; }
+}
+.splat-dropzone-icon {
+    font-size: 56px; line-height: 1; margin-bottom: 14px;
+    color: #ff7a1a;
+}
+.splat-dropzone-title {
+    font-size: 22px; font-weight: 600; margin-bottom: 8px;
+    letter-spacing: 0.01em;
+}
+.splat-dropzone-sub {
+    font-size: 12px; color: #aaa;
+    letter-spacing: 0.14em; text-transform: uppercase;
+}
+.splat-toast-container {
+    position: fixed; bottom: 16px; right: 16px;
+    display: flex; flex-direction: column; gap: 8px; align-items: flex-end;
+    z-index: 99999;
+    pointer-events: none;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+}
+.splat-toast {
+    min-width: 240px; max-width: 460px;
+    padding: 11px 14px;
+    border-radius: 8px;
+    background: #1a1a1f; color: #f5f5f5;
+    box-shadow: 0 6px 22px rgba(0, 0, 0, 0.55);
+    border-left: 3px solid #555;
+    font-size: 13px; line-height: 1.45;
+    opacity: 0; transform: translateX(24px);
+    transition: opacity 180ms ease, transform 180ms ease;
+    pointer-events: auto;
+    word-break: break-word;
+}
+.splat-toast.visible {
+    opacity: 1; transform: translateX(0);
+}
+.splat-toast.info    { border-left-color: #4a9eff; }
+.splat-toast.success { border-left-color: #2ecc71; }
+.splat-toast.error   { border-left-color: #ff5959; }
+`;
+    document.head.appendChild(style);
+}
+
+function buildOverlay() {
+    const overlay = document.createElement('div');
+    overlay.className = 'splat-dropzone-overlay';
+    overlay.innerHTML = `
+        <div class="splat-dropzone-card">
+            <div class="splat-dropzone-icon">⬇</div>
+            <div class="splat-dropzone-title">Drop to load splat</div>
+            <div class="splat-dropzone-sub">.splat &nbsp;·&nbsp; .ply &nbsp;·&nbsp; .sog</div>
+        </div>
+    `;
+    return overlay;
+}
+
+function buildToastContainer() {
+    const c = document.createElement('div');
+    c.className = 'splat-toast-container';
+    return c;
+}
+
+/**
+ * Show a toast. Returns a handle the caller can later mutate via replaceToast.
+ *
+ * @returns {{ toast: HTMLElement, dismissed: boolean }}
+ */
+function showToast(container, message, kind = 'info', { persist = false, durationMs = null } = {}) {
+    const toast = document.createElement('div');
+    toast.className = `splat-toast ${kind}`;
+    toast.textContent = message;
+    container.appendChild(toast);
+    requestAnimationFrame(() => toast.classList.add('visible'));
+
+    const handle = { toast, dismissed: false };
+
+    if (!persist) {
+        const ms = durationMs ?? (kind === 'error' ? 6000 : 4000);
+        setTimeout(() => dismissToast(handle), ms);
+    }
+    return handle;
+}
+
+/**
+ * Mutate an existing toast in place — change its kind and message — and start
+ * its auto-dismiss timer. Used to flip a "Loading…" toast into a "Loaded" or
+ * "Failed" toast without flicker.
+ */
+function replaceToast(handle, message, kind, { durationMs = null } = {}) {
+    if (!handle?.toast || handle.dismissed) return;
+    handle.toast.classList.remove('info', 'success', 'error');
+    handle.toast.classList.add(kind);
+    handle.toast.textContent = message;
+    const ms = durationMs ?? (kind === 'error' ? 6000 : 4000);
+    setTimeout(() => dismissToast(handle), ms);
+}
+
+function dismissToast(handle) {
+    if (!handle?.toast || handle.dismissed) return;
+    handle.dismissed = true;
+    handle.toast.classList.remove('visible');
+    setTimeout(() => handle.toast.remove(), 220);
+}

--- a/src/world/splat/init.js
+++ b/src/world/splat/init.js
@@ -7,18 +7,31 @@
 //
 // Behavior:
 //   - Exposes window.splatRenderer and window.splatActor for console testing.
+//   - Wires drag-and-drop file loading for .splat / .ply / .sog onto the page.
+//     Drop a file anywhere on the window to add it as a splat actor (or bare
+//     mesh, when no SceneSystem is provided). Pass `enableDropZone: false` in
+//     opts to opt out.
 //   - If the page URL has ?splat=<url>, auto-loads that splat at world origin.
 //   - When a SceneSystem is provided, splats are registered as proper actors
 //     (gizmo-editable, serializable). When omitted, falls back to a bare mesh.
 
 import * as splatRenderer from './splatRenderer.js';
 import * as splatActor from './splatActor.js';
+import { wireSplatDropZone } from './dropZone.js';
 
-export async function wireSplatDevHooks(scene, sceneSystem = null) {
+export async function wireSplatDevHooks(scene, sceneSystem = null, opts = {}) {
+    const { enableDropZone = true } = opts;
+
     // Console hooks for ad-hoc testing in DevTools.
     if (typeof window !== 'undefined') {
         window.splatRenderer = splatRenderer;
         window.splatActor    = splatActor;
+    }
+
+    // Drag-and-drop file loading. Wired before the URL auto-loader so it's
+    // available even on pages without a ?splat= query param.
+    if (enableDropZone && scene && typeof window !== 'undefined') {
+        wireSplatDropZone({ scene, sceneSystem });
     }
 
     // ?splat=<url> auto-loader.

--- a/src/world/splat/loaders/index.js
+++ b/src/world/splat/loaders/index.js
@@ -29,13 +29,18 @@ const SPLAT_BYTES   = 32;
 /**
  * Detect splat format from URL extension. Returns one of:
  *   'splat' | 'ply' | 'sog' | null
+ *
+ * Checks the path before any query/fragment first, then falls back to the full
+ * URL — so callers can stash a filename hint in the fragment of a `blob:` URL
+ * (e.g. `blob:abc#scene.ply`), since blob URLs themselves have no extension.
  */
 export function detectFormatFromUrl(url) {
     if (typeof url !== 'string') return null;
-    const path = url.split('?')[0].split('#')[0].toLowerCase();
-    if (path.endsWith('.splat')) return 'splat';
-    if (path.endsWith('.ply'))   return 'ply';
-    if (path.endsWith('.sog'))   return 'sog';
+    const lower = url.toLowerCase();
+    const path = lower.split('?')[0].split('#')[0];
+    if (path.endsWith('.splat') || lower.endsWith('.splat')) return 'splat';
+    if (path.endsWith('.ply')   || lower.endsWith('.ply'))   return 'ply';
+    if (path.endsWith('.sog')   || lower.endsWith('.sog'))   return 'sog';
     return null;
 }
 

--- a/src/world/splat/loaders/index.js
+++ b/src/world/splat/loaders/index.js
@@ -1,0 +1,149 @@
+// src/world/splat/loaders/index.js
+//
+// Format dispatcher for Gaussian Splat loaders.
+//
+// Detects the file format by extension first, falls back to magic-byte sniffing
+// for extensionless URLs, and delegates to the matching parser. All parsers
+// return the same normalized shape consumed by `buildSplatMesh`:
+//
+//   {
+//     count:     number,
+//     positions: Float32Array(count * 3),  // raw xyz
+//     scales:    Float32Array(count * 3),  // already exp(log_scale)
+//     colors:    Float32Array(count * 4),  // RGBA in [0,1]
+//     rotations: Float32Array(count * 4),  // quaternion (x,y,z,w), normalized
+//   }
+//
+// Supported formats:
+//   - .splat  Antimatter15-style raw 32-byte records (no header).
+//   - .ply    Standard 3D Gaussian Splatting PLY (binary little-endian).
+//   - .sog    PlayCanvas SuperSplat Self-Organizing Gaussian (ZIP + WebP grids).
+
+import { parsePly } from './ply.js';
+import { parseSog } from './sog.js';
+
+const PK_MAGIC      = 0x504B0304;    // "PK\x03\x04"  (ZIP local file header)
+const PK_MAGIC_EOCD = 0x504B0506;    // "PK\x05\x06"  (ZIP end-of-central-dir)
+const SPLAT_BYTES   = 32;
+
+/**
+ * Detect splat format from URL extension. Returns one of:
+ *   'splat' | 'ply' | 'sog' | null
+ */
+export function detectFormatFromUrl(url) {
+    if (typeof url !== 'string') return null;
+    const path = url.split('?')[0].split('#')[0].toLowerCase();
+    if (path.endsWith('.splat')) return 'splat';
+    if (path.endsWith('.ply'))   return 'ply';
+    if (path.endsWith('.sog'))   return 'sog';
+    return null;
+}
+
+/**
+ * Detect splat format by sniffing the first few bytes of an ArrayBuffer.
+ * Useful when the URL has no extension (e.g. content-disposition redirects).
+ */
+export function detectFormatFromBuffer(buffer) {
+    if (!(buffer instanceof ArrayBuffer) || buffer.byteLength < 4) return null;
+    const view = new DataView(buffer);
+    const magic = view.getUint32(0, false);     // big-endian read of first 4 bytes
+    if (magic === PK_MAGIC || magic === PK_MAGIC_EOCD) return 'sog';
+    // PLY ASCII header always starts with "ply\n" (or "ply\r\n").
+    if (view.getUint8(0) === 0x70 &&
+        view.getUint8(1) === 0x6C &&
+        view.getUint8(2) === 0x79) return 'ply';
+    // .splat has no magic header; caller treats this as a fallback case.
+    return null;
+}
+
+// -----------------------------------------------------------------------------
+// .splat (Antimatter15) binary parser. Inlined here to avoid a circular import
+// with splatRenderer.js (which re-exports its own copy for backward compat).
+// -----------------------------------------------------------------------------
+//
+// 32 bytes per splat, little-endian:
+//   0..11   position xyz (3 x f32)
+//   12..23  scale xyz    (3 x f32, already exp(log_scale))
+//   24..27  color RGBA   (4 x u8, divide by 255)
+//   28..31  rotation xyzw(4 x u8, decode (b - 127.5) / 127.5)
+export function parseSplatBinary(arrayBuffer) {
+    if (arrayBuffer.byteLength % SPLAT_BYTES !== 0) {
+        throw new Error(
+            `[splat-loader] .splat buffer length ${arrayBuffer.byteLength} is not a multiple of ${SPLAT_BYTES}`,
+        );
+    }
+    const view = new DataView(arrayBuffer);
+    const count = (arrayBuffer.byteLength / SPLAT_BYTES) | 0;
+    const positions = new Float32Array(count * 3);
+    const scales    = new Float32Array(count * 3);
+    const colors    = new Float32Array(count * 4);
+    const rotations = new Float32Array(count * 4);
+
+    for (let i = 0; i < count; i++) {
+        const o = i * SPLAT_BYTES;
+        positions[i * 3 + 0] = view.getFloat32(o,      true);
+        positions[i * 3 + 1] = view.getFloat32(o + 4,  true);
+        positions[i * 3 + 2] = view.getFloat32(o + 8,  true);
+        scales[i * 3 + 0]    = view.getFloat32(o + 12, true);
+        scales[i * 3 + 1]    = view.getFloat32(o + 16, true);
+        scales[i * 3 + 2]    = view.getFloat32(o + 20, true);
+        colors[i * 4 + 0]    = view.getUint8(o + 24) / 255;
+        colors[i * 4 + 1]    = view.getUint8(o + 25) / 255;
+        colors[i * 4 + 2]    = view.getUint8(o + 26) / 255;
+        colors[i * 4 + 3]    = view.getUint8(o + 27) / 255;
+        rotations[i * 4 + 0] = (view.getUint8(o + 28) - 127.5) / 127.5;
+        rotations[i * 4 + 1] = (view.getUint8(o + 29) - 127.5) / 127.5;
+        rotations[i * 4 + 2] = (view.getUint8(o + 30) - 127.5) / 127.5;
+        rotations[i * 4 + 3] = (view.getUint8(o + 31) - 127.5) / 127.5;
+    }
+    return { count, positions, scales, colors, rotations };
+}
+
+/**
+ * Parse a splat ArrayBuffer of any supported format. Useful when you've
+ * already fetched the bytes (e.g. from a drag-and-drop file input).
+ *
+ * @param {ArrayBuffer} buffer
+ * @param {string} [hint]  Optional URL or filename for extension-based detection.
+ * @returns {Promise<{count, positions, scales, colors, rotations}>}
+ */
+export async function parseSplatAny(buffer, hint = '') {
+    const format =
+        detectFormatFromUrl(hint) ||
+        detectFormatFromBuffer(buffer) ||
+        (buffer.byteLength > 0 && buffer.byteLength % SPLAT_BYTES === 0 ? 'splat' : null);
+
+    if (!format) {
+        throw new Error(
+            `[splat-loader] cannot detect splat format` +
+            (hint ? ` for ${hint}` : '') +
+            ` (got ${buffer.byteLength} bytes, no recognizable magic).`,
+        );
+    }
+
+    switch (format) {
+        case 'splat': return parseSplatBinary(buffer);
+        case 'ply':   return parsePly(buffer);
+        case 'sog':   return await parseSog(buffer);
+        default:
+            throw new Error(`[splat-loader] unsupported format: ${format}`);
+    }
+}
+
+/**
+ * Load a splat file by URL, returning the normalized data shape.
+ *
+ *   const data = await loadSplatAny('https://example.com/scene.ply');
+ *   const mesh = buildSplatMesh(data);
+ */
+export async function loadSplatAny(url) {
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`[splat-loader] fetch failed: ${response.status} ${response.statusText} for ${url}`);
+    }
+    const buffer = await response.arrayBuffer();
+    return parseSplatAny(buffer, url);
+}
+
+// Re-export sub-loaders for callers who want to bypass detection.
+export { parsePly, parseSog };

--- a/src/world/splat/loaders/ply.js
+++ b/src/world/splat/loaders/ply.js
@@ -1,0 +1,247 @@
+// src/world/splat/loaders/ply.js
+//
+// Standard 3D Gaussian Splatting PLY parser (Kerbl et al. 2023 export format).
+//
+// File layout:
+//   ASCII header up to and including `end_header\n`, then a binary little-endian
+//   payload of `vertex_count` records, each holding the properties listed in the
+//   header (in declared order) — typically:
+//
+//     x, y, z, nx, ny, nz,
+//     f_dc_0, f_dc_1, f_dc_2,           // SH band 0 (DC)  -> RGB
+//     f_rest_0 .. f_rest_44,            // SH bands 1..3 (optional)
+//     opacity,                          // logit; sigmoid -> alpha
+//     scale_0, scale_1, scale_2,        // log-scale; exp -> world scale
+//     rot_0, rot_1, rot_2, rot_3        // quaternion (w, x, y, z)  ← w-first!
+//
+// Conversions to our normalized SplatData:
+//   color:    RGB = clamp01(0.5 + 0.28209479177 * f_dc_n);  alpha = sigmoid(opacity)
+//   scale:    Math.exp(scale_n)
+//   rotation: rearrange (w,x,y,z) → (x,y,z,w), then normalize
+//
+// We currently discard f_rest_* (no view-dependent SH yet — Phase 1.5 work).
+//
+// Reference impls used for cross-checking conventions:
+//   - antimatter15/splat (PLY → .splat converter): rot_0 is W
+//   - mkkellogg/GaussianSplats3D
+//   - playcanvas/splat-transform: src/lib/readers/read-ply.ts
+
+const SH_C0 = 0.28209479177387814;    // 0th-order SH basis constant
+const TEXT_DECODER = new TextDecoder('utf-8');
+
+const PROP_SIZE = {
+    char:    1, uchar:  1, int8:   1, uint8:  1,
+    short:   2, ushort: 2, int16:  2, uint16: 2,
+    int:     4, uint:   4, int32:  4, uint32: 4,
+    float:   4, float32: 4,
+    double:  8, float64: 8,
+};
+
+const PROP_READER = {
+    char:    (dv, o, le) => dv.getInt8(o),
+    int8:    (dv, o, le) => dv.getInt8(o),
+    uchar:   (dv, o, le) => dv.getUint8(o),
+    uint8:   (dv, o, le) => dv.getUint8(o),
+    short:   (dv, o, le) => dv.getInt16(o, le),
+    int16:   (dv, o, le) => dv.getInt16(o, le),
+    ushort:  (dv, o, le) => dv.getUint16(o, le),
+    uint16:  (dv, o, le) => dv.getUint16(o, le),
+    int:     (dv, o, le) => dv.getInt32(o, le),
+    int32:   (dv, o, le) => dv.getInt32(o, le),
+    uint:    (dv, o, le) => dv.getUint32(o, le),
+    uint32:  (dv, o, le) => dv.getUint32(o, le),
+    float:   (dv, o, le) => dv.getFloat32(o, le),
+    float32: (dv, o, le) => dv.getFloat32(o, le),
+    double:  (dv, o, le) => dv.getFloat64(o, le),
+    float64: (dv, o, le) => dv.getFloat64(o, le),
+};
+
+// -----------------------------------------------------------------------------
+// Header parsing
+// -----------------------------------------------------------------------------
+
+/**
+ * Locate the byte offset just past `end_header\n` in the buffer.
+ * Decodes only the leading slice (PLY headers are small ASCII).
+ *
+ * @param {ArrayBuffer} buffer
+ * @returns {{ headerText: string, dataOffset: number }}
+ */
+function readHeader(buffer) {
+    const slice  = new Uint8Array(buffer, 0, Math.min(buffer.byteLength, 65536));
+    const ascii  = TEXT_DECODER.decode(slice);
+    const marker = ascii.indexOf('end_header');
+    if (marker < 0) {
+        throw new Error('[splat-ply] end_header not found in first 64 KB of file');
+    }
+    // Header may end with "end_header\n" or "end_header\r\n".
+    const after = ascii.indexOf('\n', marker);
+    if (after < 0) throw new Error('[splat-ply] malformed header (no newline after end_header)');
+
+    // Re-encode the header substring to get its true byte length, since the
+    // 64 KB ASCII slice may contain non-ASCII bytes that don't correspond 1:1.
+    const headerBytes = new TextEncoder().encode(ascii.slice(0, after + 1));
+    return { headerText: ascii.slice(0, after + 1), dataOffset: headerBytes.byteLength };
+}
+
+/**
+ * Parse the header text into a structured form.
+ *
+ * @param {string} headerText
+ * @returns {{ format: string, vertexCount: number, properties: Array<{name:string,type:string,size:number}> }}
+ */
+function parseHeader(headerText) {
+    const lines = headerText.split(/\r?\n/);
+    let format       = '';
+    let vertexCount  = 0;
+    const properties = [];
+    let inVertexElement = false;
+
+    for (const raw of lines) {
+        const line = raw.trim();
+        if (line === '' || line === 'ply' || line === 'end_header' || line.startsWith('comment')) continue;
+
+        if (line.startsWith('format ')) {
+            format = line.slice('format '.length).split(' ')[0];
+            continue;
+        }
+        if (line.startsWith('element ')) {
+            const [, name, count] = line.split(/\s+/);
+            inVertexElement = (name === 'vertex');
+            if (inVertexElement) vertexCount = parseInt(count, 10);
+            continue;
+        }
+        if (line.startsWith('property ')) {
+            if (!inVertexElement) continue;     // skip e.g. face properties
+            // "property <type> <name>"  or  "property list <count_type> <type> <name>"
+            const tokens = line.split(/\s+/);
+            if (tokens[1] === 'list') continue; // we don't need list properties for splats
+            const type = tokens[1];
+            const name = tokens[2];
+            const size = PROP_SIZE[type];
+            if (size === undefined) {
+                throw new Error(`[splat-ply] unsupported property type "${type}" for "${name}"`);
+            }
+            properties.push({ name, type, size });
+        }
+    }
+
+    if (format !== 'binary_little_endian') {
+        throw new Error(
+            `[splat-ply] unsupported format "${format}". ` +
+            `Only binary_little_endian PLY is supported (export from 3DGS / SuperSplat / etc.).`,
+        );
+    }
+    if (!vertexCount) throw new Error('[splat-ply] header declares zero or missing vertex count');
+    if (!properties.length) throw new Error('[splat-ply] header declares no vertex properties');
+
+    return { format, vertexCount, properties };
+}
+
+// -----------------------------------------------------------------------------
+// Body parsing
+// -----------------------------------------------------------------------------
+
+const REQUIRED = ['x', 'y', 'z', 'opacity', 'scale_0', 'scale_1', 'scale_2',
+                  'rot_0', 'rot_1', 'rot_2', 'rot_3'];
+
+/**
+ * Parse a Gaussian-flavored PLY ArrayBuffer into the normalized splat shape.
+ *
+ * @param {ArrayBuffer} buffer
+ * @returns {{count, positions, scales, colors, rotations}}
+ */
+export function parsePly(buffer) {
+    const { headerText, dataOffset } = readHeader(buffer);
+    const { vertexCount, properties } = parseHeader(headerText);
+
+    // Compute byte stride and per-property offset within the stride.
+    const stride = properties.reduce((sum, p) => sum + p.size, 0);
+    const offsets = {};
+    let cursor = 0;
+    for (const p of properties) {
+        offsets[p.name] = { offset: cursor, type: p.type };
+        cursor += p.size;
+    }
+
+    // Sanity-check: file must be long enough to hold all records.
+    const bodyBytes = buffer.byteLength - dataOffset;
+    if (bodyBytes < stride * vertexCount) {
+        throw new Error(
+            `[splat-ply] truncated body: expected ${stride * vertexCount} bytes, ` +
+            `got ${bodyBytes} (header offset=${dataOffset}, file=${buffer.byteLength})`,
+        );
+    }
+
+    // Verify required properties are present. f_dc_0..2 are also expected for
+    // color but we degrade gracefully (white) if missing.
+    for (const name of REQUIRED) {
+        if (!(name in offsets)) {
+            throw new Error(`[splat-ply] required property "${name}" missing from header`);
+        }
+    }
+    const hasDC = offsets.f_dc_0 && offsets.f_dc_1 && offsets.f_dc_2;
+
+    const dv = new DataView(buffer, dataOffset, bodyBytes);
+    const positions = new Float32Array(vertexCount * 3);
+    const scales    = new Float32Array(vertexCount * 3);
+    const colors    = new Float32Array(vertexCount * 4);
+    const rotations = new Float32Array(vertexCount * 4);
+
+    // Hoist readers into locals so the hot loop avoids object indirection.
+    const read = (name, base) => {
+        const { offset, type } = offsets[name];
+        return PROP_READER[type](dv, base + offset, true);
+    };
+
+    for (let i = 0; i < vertexCount; i++) {
+        const base = i * stride;
+
+        // Position
+        positions[i * 3 + 0] = read('x', base);
+        positions[i * 3 + 1] = read('y', base);
+        positions[i * 3 + 2] = read('z', base);
+
+        // Scales (raw is log-scale; renderer expects already-exp'd values)
+        scales[i * 3 + 0] = Math.exp(read('scale_0', base));
+        scales[i * 3 + 1] = Math.exp(read('scale_1', base));
+        scales[i * 3 + 2] = Math.exp(read('scale_2', base));
+
+        // Color: SH DC band → linear RGB; opacity → sigmoid alpha.
+        if (hasDC) {
+            const r = 0.5 + SH_C0 * read('f_dc_0', base);
+            const g = 0.5 + SH_C0 * read('f_dc_1', base);
+            const b = 0.5 + SH_C0 * read('f_dc_2', base);
+            colors[i * 4 + 0] = Math.max(0, Math.min(1, r));
+            colors[i * 4 + 1] = Math.max(0, Math.min(1, g));
+            colors[i * 4 + 2] = Math.max(0, Math.min(1, b));
+        } else {
+            colors[i * 4 + 0] = 1;
+            colors[i * 4 + 1] = 1;
+            colors[i * 4 + 2] = 1;
+        }
+        const opacityRaw = read('opacity', base);
+        colors[i * 4 + 3] = 1 / (1 + Math.exp(-opacityRaw));     // sigmoid
+
+        // Rotation: PLY stores (w, x, y, z); renderer wants (x, y, z, w).
+        const qw = read('rot_0', base);
+        const qx = read('rot_1', base);
+        const qy = read('rot_2', base);
+        const qz = read('rot_3', base);
+        const len = Math.hypot(qx, qy, qz, qw) || 1;
+        rotations[i * 4 + 0] = qx / len;
+        rotations[i * 4 + 1] = qy / len;
+        rotations[i * 4 + 2] = qz / len;
+        rotations[i * 4 + 3] = qw / len;
+    }
+
+    return { count: vertexCount, positions, scales, colors, rotations };
+}
+
+/**
+ * Convenience: fetch + parse. Mirrors the renderer's `loadSplat(url)` API.
+ */
+export async function loadPly(url) {
+    const buf = await (await fetch(url)).arrayBuffer();
+    return parsePly(buf);
+}

--- a/src/world/splat/loaders/sog.js
+++ b/src/world/splat/loaders/sog.js
@@ -1,0 +1,372 @@
+// src/world/splat/loaders/sog.js
+//
+// PlayCanvas SuperSplat SOG (Self-Organizing Gaussian) loader.
+//
+// Format reference (verified against playcanvas/splat-transform `read-sog.ts`
+// and `write-sog.ts`):
+//
+//   - Container: ZIP archive with `PK\x03\x04` magic. Entries (flat, no subdirs):
+//       meta.json
+//       means_l.webp           position low byte    (RGBA8888 lossless WebP)
+//       means_u.webp           position high byte   (RGBA8888 lossless WebP)
+//       quats.webp             quaternion (largest-component-omitted)
+//       scales.webp            per-channel codebook indices
+//       sh0.webp               color codebook indices (RGB) + sigmoid opacity (A)
+//       shN_centroids.webp     optional: higher-order SH palette
+//       shN_labels.webp        optional: per-Gaussian palette index (16-bit)
+//
+//   - meta.json:
+//       {
+//         version: 2,
+//         asset: { generator },
+//         count,
+//         means:    { mins:[x,y,z], maxs:[x,y,z], files:[...] },
+//         scales:   { codebook:[float...],          files:[...] },
+//         quats:    {                                files:[...] },
+//         sh0:      { codebook:[float...],          files:[...] },
+//         shN?:     { count, bands, codebook,       files:[...] }
+//       }
+//
+//   - Texture dimensions: width = ceil(sqrt(count)/4)*4, height = ceil(count/width/4)*4.
+//     Both are multiples of 4 (texture is padded; Gaussians fill in Morton order).
+//
+// Output matches the normalized splat shape used by buildSplatMesh:
+//   { count, positions: F32[N*3], scales: F32[N*3], colors: F32[N*4], rotations: F32[N*4] }
+//
+// Phase 2.5 limitations (deferred):
+//   - shN higher SH bands are ignored (no view-dependent SH rendering yet).
+
+const SH_C0 = 0.28209479177387814;
+const TEXT_DECODER = new TextDecoder('utf-8');
+
+// =============================================================================
+// Public entry points
+// =============================================================================
+
+/**
+ * Parse a SOG ArrayBuffer into normalized splat data.
+ * @param {ArrayBuffer} buffer
+ * @returns {Promise<{count, positions, scales, colors, rotations}>}
+ */
+export async function parseSog(buffer) {
+    const entries = await readZip(buffer);
+    const metaEntry = entries.get('meta.json');
+    if (!metaEntry) {
+        throw new Error('[splat-sog] meta.json not found in SOG archive');
+    }
+    const meta = JSON.parse(TEXT_DECODER.decode(metaEntry));
+    return decodeSog(meta, entries);
+}
+
+/**
+ * Convenience: fetch + parse.
+ */
+export async function loadSog(url) {
+    const buf = await (await fetch(url)).arrayBuffer();
+    return parseSog(buf);
+}
+
+// =============================================================================
+// Decode pipeline
+// =============================================================================
+
+async function decodeSog(meta, entries) {
+    const { count } = meta;
+    if (!count || count <= 0) {
+        throw new Error(`[splat-sog] meta.count is invalid: ${count}`);
+    }
+    if (!meta.means?.files?.length || meta.means.files.length < 2) {
+        throw new Error('[splat-sog] meta.means.files must list two textures (low + high)');
+    }
+    if (!meta.quats?.files?.length || !meta.scales?.files?.length || !meta.sh0?.files?.length) {
+        throw new Error('[splat-sog] meta is missing one of: quats / scales / sh0');
+    }
+
+    // Decode all required image attributes in parallel.
+    const [meansLo, meansHi, quats, scales, sh0] = await Promise.all([
+        decodeWebpEntry(entries, meta.means.files[0]),
+        decodeWebpEntry(entries, meta.means.files[1]),
+        decodeWebpEntry(entries, meta.quats.files[0]),
+        decodeWebpEntry(entries, meta.scales.files[0]),
+        decodeWebpEntry(entries, meta.sh0.files[0]),
+    ]);
+
+    const positions = decodePositions(meansLo, meansHi, count, meta.means);
+    const rotations = decodeQuats(quats, count);
+    const out_scales = decodeScales(scales, count, meta.scales.codebook);
+    const colors = decodeColorsAndOpacity(sh0, count, meta.sh0.codebook);
+
+    return { count, positions, scales: out_scales, colors, rotations };
+}
+
+// -----------------------------------------------------------------------------
+// Positions: 16-bit split precision (low + high bytes), with log-space mapping.
+// -----------------------------------------------------------------------------
+function decodePositions(lo, hi, count, meansMeta) {
+    const mins = meansMeta.mins;
+    const maxs = meansMeta.maxs;
+    const rx = maxs[0] - mins[0];
+    const ry = maxs[1] - mins[1];
+    const rz = maxs[2] - mins[2];
+
+    const positions = new Float32Array(count * 3);
+    const inv65535 = 1 / 65535;
+
+    for (let i = 0; i < count; i++) {
+        const base = i * 4;
+        const xi = lo[base + 0] | (hi[base + 0] << 8);
+        const yi = lo[base + 1] | (hi[base + 1] << 8);
+        const zi = lo[base + 2] | (hi[base + 2] << 8);
+
+        // Unnormalize from log-space range stored in meta.means.{mins,maxs}.
+        const lx = mins[0] + rx * (xi * inv65535);
+        const ly = mins[1] + ry * (yi * inv65535);
+        const lz = mins[2] + rz * (zi * inv65535);
+
+        // Inverse log transform: sign(v) * (exp(|v|) - 1).
+        positions[i * 3 + 0] = Math.sign(lx) * (Math.exp(Math.abs(lx)) - 1);
+        positions[i * 3 + 1] = Math.sign(ly) * (Math.exp(Math.abs(ly)) - 1);
+        positions[i * 3 + 2] = Math.sign(lz) * (Math.exp(Math.abs(lz)) - 1);
+    }
+    return positions;
+}
+
+// -----------------------------------------------------------------------------
+// Quaternions: largest-component-omitted, recovery from sqrt(1 - sum(others^2)).
+// Output order: (x, y, z, w) per the renderer's expectations.
+// -----------------------------------------------------------------------------
+//
+// Tag (alpha channel) encodes which component was omitted:
+//   tag = 252 -> q[0] (x) is the largest, omitted; a/b/c go to q[1],q[2],q[3]
+//   tag = 253 -> q[1] (y) omitted; a/b/c -> q[0],q[2],q[3]
+//   tag = 254 -> q[2] (z) omitted; a/b/c -> q[0],q[1],q[3]
+//   tag = 255 -> q[3] (w) omitted; a/b/c -> q[0],q[1],q[2]
+const QUAT_SLOTS = [
+    [1, 2, 3, 0],
+    [0, 2, 3, 1],
+    [0, 1, 3, 2],
+    [0, 1, 2, 3],
+];
+const SQRT2_INV = 1 / Math.sqrt(2);
+
+function decodeQuats(rgba, count) {
+    const out = new Float32Array(count * 4);
+    for (let i = 0; i < count; i++) {
+        const base = i * 4;
+        const tagByte = rgba[base + 3];
+        const tag = tagByte - 252;
+        const slot = (tag >= 0 && tag < 4) ? QUAT_SLOTS[tag] : QUAT_SLOTS[3];
+
+        const a = (rgba[base + 0] / 255 * 2 - 1) * SQRT2_INV;
+        const b = (rgba[base + 1] / 255 * 2 - 1) * SQRT2_INV;
+        const c = (rgba[base + 2] / 255 * 2 - 1) * SQRT2_INV;
+
+        const q = [0, 0, 0, 0];
+        q[slot[0]] = a;
+        q[slot[1]] = b;
+        q[slot[2]] = c;
+        const recoverIdx = slot[3];
+        const t = 1 - (a * a + b * b + c * c);
+        q[recoverIdx] = Math.sqrt(Math.max(0, t));
+
+        // Normalize defensively (encoder makes it unit, FP rounding drifts).
+        const len = Math.hypot(q[0], q[1], q[2], q[3]) || 1;
+        out[i * 4 + 0] = q[0] / len;
+        out[i * 4 + 1] = q[1] / len;
+        out[i * 4 + 2] = q[2] / len;
+        out[i * 4 + 3] = q[3] / len;
+    }
+    return out;
+}
+
+// -----------------------------------------------------------------------------
+// Scales: codebook lookup of log-scale, then exp() to world scale.
+// -----------------------------------------------------------------------------
+function decodeScales(rgba, count, codebook) {
+    if (!codebook || codebook.length === 0) {
+        throw new Error('[splat-sog] meta.scales.codebook is missing or empty');
+    }
+    const cb = codebook;
+    const out = new Float32Array(count * 3);
+    for (let i = 0; i < count; i++) {
+        const base = i * 4;
+        out[i * 3 + 0] = Math.exp(cb[rgba[base + 0]]);
+        out[i * 3 + 1] = Math.exp(cb[rgba[base + 1]]);
+        out[i * 3 + 2] = Math.exp(cb[rgba[base + 2]]);
+    }
+    return out;
+}
+
+// -----------------------------------------------------------------------------
+// Color (SH DC band) + opacity (already sigmoid'd).
+// -----------------------------------------------------------------------------
+function decodeColorsAndOpacity(rgba, count, codebook) {
+    if (!codebook || codebook.length === 0) {
+        throw new Error('[splat-sog] meta.sh0.codebook is missing or empty');
+    }
+    const cb = codebook;
+    const inv255 = 1 / 255;
+    const out = new Float32Array(count * 4);
+    for (let i = 0; i < count; i++) {
+        const base = i * 4;
+        const fdc0 = cb[rgba[base + 0]];
+        const fdc1 = cb[rgba[base + 1]];
+        const fdc2 = cb[rgba[base + 2]];
+
+        const r = 0.5 + SH_C0 * fdc0;
+        const g = 0.5 + SH_C0 * fdc1;
+        const b = 0.5 + SH_C0 * fdc2;
+
+        out[i * 4 + 0] = Math.max(0, Math.min(1, r));
+        out[i * 4 + 1] = Math.max(0, Math.min(1, g));
+        out[i * 4 + 2] = Math.max(0, Math.min(1, b));
+        out[i * 4 + 3] = rgba[base + 3] * inv255;        // alpha already in [0,1]
+    }
+    return out;
+}
+
+// =============================================================================
+// WebP decoding via createImageBitmap + OffscreenCanvas
+// =============================================================================
+
+/**
+ * Decode a WebP entry from the ZIP map into a raw RGBA pixel buffer.
+ * Returns the underlying Uint8ClampedArray (length = width * height * 4).
+ */
+async function decodeWebpEntry(entries, name) {
+    const bytes = entries.get(name);
+    if (!bytes) {
+        throw new Error(`[splat-sog] missing entry "${name}" in archive`);
+    }
+    if (typeof createImageBitmap !== 'function') {
+        throw new Error(
+            '[splat-sog] createImageBitmap is unavailable. ' +
+            'SOG decoding requires a browser or worker context.',
+        );
+    }
+
+    const blob = new Blob([bytes], { type: 'image/webp' });
+    const bitmap = await createImageBitmap(blob);
+
+    const w = bitmap.width;
+    const h = bitmap.height;
+
+    // Prefer OffscreenCanvas (works in workers); fall back to a detached
+    // <canvas> on the main thread.
+    let canvas;
+    if (typeof OffscreenCanvas === 'function') {
+        canvas = new OffscreenCanvas(w, h);
+    } else if (typeof document !== 'undefined') {
+        canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+    } else {
+        throw new Error('[splat-sog] no OffscreenCanvas or document available for WebP decode');
+    }
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    ctx.drawImage(bitmap, 0, 0);
+    bitmap.close?.();
+    const imageData = ctx.getImageData(0, 0, w, h);
+    return imageData.data;       // Uint8ClampedArray, RGBA row-major
+}
+
+// =============================================================================
+// Minimal ZIP reader (central-directory based)
+// =============================================================================
+//
+// Handles:
+//   - Method 0 (stored / no compression) — the default for already-compressed
+//     WebP entries inside SOG archives.
+//   - Method 8 (deflate) via the native DecompressionStream API.
+//
+// Does NOT handle:
+//   - Encryption
+//   - ZIP64 (files > 4 GB) — SOG archives are small, this is fine.
+//   - Multi-volume archives.
+//
+// Returns a Map<filename, Uint8Array>.
+
+const SIG_LOCAL = 0x04034b50;
+const SIG_CDIR  = 0x02014b50;
+const SIG_EOCD  = 0x06054b50;
+
+async function readZip(buffer) {
+    const dv = new DataView(buffer);
+    const entries = new Map();
+
+    // 1. Locate End-of-Central-Directory by scanning backward for the EOCD signature.
+    //    EOCD is 22 bytes minimum, optionally followed by a comment up to 64 KB.
+    const fileLen = buffer.byteLength;
+    const minEocdOffset = Math.max(0, fileLen - 22 - 0xFFFF);
+    let eocdOffset = -1;
+    for (let i = fileLen - 22; i >= minEocdOffset; i--) {
+        if (dv.getUint32(i, true) === SIG_EOCD) {
+            eocdOffset = i;
+            break;
+        }
+    }
+    if (eocdOffset < 0) {
+        throw new Error('[splat-sog] not a ZIP archive (no EOCD signature found)');
+    }
+
+    const cdirEntries = dv.getUint16(eocdOffset + 10, true);
+    const cdirOffset  = dv.getUint32(eocdOffset + 16, true);
+
+    // 2. Walk central directory; collect inflate jobs to run in parallel.
+    const inflateJobs = [];
+    let p = cdirOffset;
+    for (let i = 0; i < cdirEntries; i++) {
+        if (dv.getUint32(p, true) !== SIG_CDIR) {
+            throw new Error(`[splat-sog] malformed central directory at offset ${p}`);
+        }
+        const compMethod    = dv.getUint16(p + 10, true);
+        const compSize      = dv.getUint32(p + 20, true);
+        const uncompSize    = dv.getUint32(p + 24, true);
+        const nameLen       = dv.getUint16(p + 28, true);
+        const extraLen      = dv.getUint16(p + 30, true);
+        const commentLen    = dv.getUint16(p + 32, true);
+        const localHeaderAt = dv.getUint32(p + 42, true);
+        const name = TEXT_DECODER.decode(new Uint8Array(buffer, p + 46, nameLen));
+
+        // 3. Read the local file header to find where the actual data begins.
+        if (dv.getUint32(localHeaderAt, true) !== SIG_LOCAL) {
+            throw new Error(`[splat-sog] malformed local header for "${name}"`);
+        }
+        const lfhNameLen  = dv.getUint16(localHeaderAt + 26, true);
+        const lfhExtraLen = dv.getUint16(localHeaderAt + 28, true);
+        const dataStart   = localHeaderAt + 30 + lfhNameLen + lfhExtraLen;
+
+        if (compMethod === 0) {
+            // Stored: data is verbatim.
+            entries.set(name, new Uint8Array(buffer, dataStart, uncompSize));
+        } else if (compMethod === 8) {
+            // Deflate: defer to inflate pass below.
+            const compressed = new Uint8Array(buffer, dataStart, compSize);
+            inflateJobs.push({ name, compressed });
+        } else {
+            throw new Error(
+                `[splat-sog] unsupported compression method ${compMethod} for "${name}". ` +
+                `Only stored (0) and deflate (8) are supported.`,
+            );
+        }
+
+        p += 46 + nameLen + extraLen + commentLen;
+    }
+
+    // 4. Inflate any deflated entries in parallel.
+    if (inflateJobs.length) {
+        if (typeof DecompressionStream !== 'function') {
+            throw new Error(
+                '[splat-sog] archive contains deflated entries but DecompressionStream is unavailable',
+            );
+        }
+        await Promise.all(inflateJobs.map(async ({ name, compressed }) => {
+            const stream = new Blob([compressed]).stream()
+                .pipeThrough(new DecompressionStream('deflate-raw'));
+            const inflated = new Uint8Array(await new Response(stream).arrayBuffer());
+            entries.set(name, inflated);
+        }));
+    }
+
+    return entries;
+}

--- a/src/world/splat/splatRenderer.js
+++ b/src/world/splat/splatRenderer.js
@@ -32,6 +32,7 @@ import {
     dot, exp, max, sqrt,
 } from 'three/tsl';
 import { loadSplatAny } from './loaders/index.js';
+import { attachDepthSort } from './depthSort.js';
 
 // .splat byte layout: 32 bytes per splat, little-endian.
 //   0..11   position xyz (3 x f32)
@@ -118,8 +119,15 @@ export function buildSplatMesh({ count, positions, scales, colors, rotations }) 
         const sc  = attribute('splatColor');
         const sr  = attribute('splatRot');
 
+        // Normalize the quaternion before building R. .splat byte-quantized
+        // rotations aren't exactly unit (per-component error ~1/256), and PLY/SOG
+        // can drift from FP rounding. A non-unit quaternion produces a rotation
+        // matrix with baked-in scale, which combined with the splat's scale
+        // diagonal gives degenerate covariance and visible streaking.
+        const qn = sr.div(max(sqrt(dot(sr, sr)), float(0.0001)));
+
         // Quaternion (x,y,z,w) -> 3x3 rotation matrix.
-        const x = sr.x, y = sr.y, z = sr.z, w = sr.w;
+        const x = qn.x, y = qn.y, z = qn.z, w = qn.w;
         const R = mat3(
             vec3(float(1).sub(float(2).mul(y.mul(y).add(z.mul(z)))),
                  float(2).mul(x.mul(y).add(w.mul(z))),
@@ -194,8 +202,12 @@ export function buildSplatMesh({ count, positions, scales, colors, rotations }) 
         // 2D Gaussian: alpha = alpha_splat * exp(-0.5 * ||vQuad||^2).
         // Because we expanded the quad in the eigenbasis with 3*sqrt(lambda) units,
         // ||vQuad||^2 is exactly the squared Mahalanobis distance.
-        const r2    = dot(vQuad, vQuad);
-        const alpha = exp(r2.mul(-0.5)).mul(vColor.a);
+        const r2  = dot(vQuad, vQuad);
+        const raw = exp(r2.mul(-0.5)).mul(vColor.a);
+        // Hard cutoff for the long faint tail beyond ~2.5 sigma. Below 1/255
+        // the framebuffer can't represent the contribution anyway, and the
+        // tails are what give un-sorted splats the visible "streaks" feel.
+        const alpha = raw.sub(0.004).max(0);
         return vec4(vColor.rgb, alpha);
     })();
 
@@ -213,6 +225,12 @@ export function buildSplatMesh({ count, positions, scales, colors, rotations }) 
         );
         uViewport.value.copy(size);
     };
+
+    // Throttled CPU back-to-front depth sort. Wraps onBeforeRender so the
+    // camera uniform update above still runs. Without this, alpha-blended
+    // splats render in load order and the result reads as visible "marks"
+    // rather than a coherent surface — see depthSort.js for the rationale.
+    attachDepthSort(mesh, { count, positions, scales, colors, rotations });
 
     return mesh;
 }

--- a/src/world/splat/splatRenderer.js
+++ b/src/world/splat/splatRenderer.js
@@ -31,6 +31,7 @@ import {
     positionLocal, modelViewMatrix, cameraProjectionMatrix,
     dot, exp, max, sqrt,
 } from 'three/tsl';
+import { loadSplatAny } from './loaders/index.js';
 
 // .splat byte layout: 32 bytes per splat, little-endian.
 //   0..11   position xyz (3 x f32)
@@ -70,14 +71,12 @@ export function parseSplat(arrayBuffer) {
     return { count, positions, scales, colors, rotations };
 }
 
+// Format-aware loader. Detects .splat, .ply, and .sog from extension/magic bytes
+// and delegates to the matching parser; all return the same normalized shape.
+// See `./loaders/index.js` for detection logic and `./loaders/{ply,sog}.js`
+// for the per-format implementations.
 export async function loadSplat(url) {
-    const buf = await (await fetch(url)).arrayBuffer();
-    if (buf.byteLength % SPLAT_BYTES !== 0) {
-        throw new Error(
-            `[splat] ${url} is not a multiple of ${SPLAT_BYTES} bytes (size=${buf.byteLength})`
-        );
-    }
-    return parseSplat(buf);
+    return loadSplatAny(url);
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
Closes the Phase 2 follow-up and adds Phase 2.5 from issue #16: load `.ply` and `.sog` files in addition to `.splat`, plus a drag-and-drop file upload UI so users can load splats by dropping files onto the page (no `?splat=` URL needed).

## ⚡ ACTION REQUIRED after merging

Add these **two lines** to root `main.js` so the splat module activates when the app boots:

```js
// 1. Add to imports (near the top, alongside other ./src/* imports):
import { wireSplatDevHooks } from './src/world/splat/init.js';

// 2. Add to the existing init().then() chain:
init().then(() => {
    applyMobileModeState();
    wireSplatDevHooks(scene, sceneSystem);   // <-- this line
}).catch((err) => console.error('init failed', err));
```

This activates: `window.splatRenderer` / `window.splatActor` console hooks, `?splat=<url>` auto-loader, AND the drag-and-drop UI.

## What lands

New files under `src/world/splat/loaders/`:

| File | What it does |
| --- | --- |
| `index.js` | Format dispatcher. `detectFormatFromUrl` (extension + blob URL fragment), `detectFormatFromBuffer` (magic-byte sniff), `parseSplatBinary`, `parseSplatAny`, `loadSplatAny`. |
| `ply.js`   | Standard 3D Gaussian Splatting PLY reader (Kerbl et al. 2023). Binary little-endian header parse, SH C0 → linear RGB, sigmoid(opacity), exp(scale_n), rotation reorder `(w,x,y,z) → (x,y,z,w)` + renormalize. `f_rest_*` is parsed but discarded for now. |
| `sog.js`   | PlayCanvas SuperSplat compressed (Self-Organizing Gaussian) reader. Native ZIP central-directory parser (no external deps), WebP decode via `createImageBitmap` + `OffscreenCanvas`, native `DecompressionStream('deflate-raw')` for any deflated entries. 16-bit split-precision positions in log space, largest-component-omitted quaternions, codebook-indexed scales / sh0. Spec verified against [`playcanvas/splat-transform`](https://github.com/playcanvas/splat-transform). |

New file `src/world/splat/dropZone.js` (drag-and-drop UI):
- Self-contained: injects its own `<style>` + creates overlay/toast DOM. No CSS or HTML changes to the main app.
- Listens on `window` so users can drop anywhere on the page.
- Drag-in shows a full-screen dashed-border overlay (`Drop to load splat`).
- Loading shows a persistent info toast; success/error toasts auto-dismiss.
- Multiple files dropped at once load sequentially (memory-safe for 84 MB SOGs).
- Uses blob URLs internally and routes through the same `loadSplatAny` path as `?splat=`, so all three formats work transparently.

Wiring:

- `splatRenderer.js`: `loadSplat(url)` now delegates to `loadSplatAny`. `parseSplat` (32-byte) is preserved.
- `init.js` (`wireSplatDevHooks`): now also wires drag-and-drop by default. Pass `{ enableDropZone: false }` to opt out.
- `sceneSerialization.js`: imports `createSplatActor`. Splat actors now round-trip through scene save/load.
- `README.md`: documents `.splat` / `.ply` / `.sog`, the loader architecture, the drag-and-drop UI, and the blob-URL persistence limitation.

## Normalized shape

Every loader returns the same struct, which is exactly what `buildSplatMesh` expects:
```js
{
  count:     number,
  positions: Float32Array(count * 3),  // raw xyz
  scales:    Float32Array(count * 3),  // already exp(log_scale)
  colors:    Float32Array(count * 4),  // RGBA in [0,1]
  rotations: Float32Array(count * 4),  // quaternion (x,y,z,w), normalized
}
```
So swapping in any format is transparent to the renderer.

## Verified locally

Synthetic-input tests pass for:
- **PLY** (3 vertices): identity round-trip on positions; `exp(-1) ≈ 0.3679` on scales; SH C0 conversion + sigmoid opacity match expected; `(w,x,y,z) → (x,y,z,w)` reorder confirmed.
- **SOG** (synthetic ZIP + 1-pixel attribute textures, with a `createImageBitmap` mock): position log-inverse `e - 1 ≈ 1.7183`; codebook lookup + `exp(ln 2) = 2`; SH C0 + opacity decode; quaternion identity from largest-component scheme.
- **Dispatcher**: extension detection covers query strings, fragments, uppercase, AND blob URL fragment hints (e.g. `blob:abc#scene.ply` → `'ply'`); magic-byte sniff distinguishes ZIP from PLY from raw `.splat`.

## Test plan (manual, in the running app)

After adding the 2 lines above to `main.js`:

- [ ] Drag a `.splat` file onto the canvas — dashed overlay appears, drop adds it as an actor at origin.
- [ ] Drag a `.ply` file onto the canvas — same flow.
- [ ] Drag a `.sog` file (e.g. the @tmate Perseverance rover, 84 MB) onto the canvas — loads and renders.
- [ ] Drag a non-splat file (e.g. `.txt`) — red error toast, no actor created.
- [ ] Drag two `.ply` files at once — they load sequentially, each shows its own toast.
- [ ] Visit `?splat=https://.../scene.ply` — still works (URL hook unchanged).
- [ ] Open Blueprint Editor, scale/rotate/translate a splat actor — transformed ellipses still render correctly (Phase 2 fix still works through the new path).
- [ ] Save scene → reload page → load scene back. URL-loaded splats round-trip; dropped (blob URL) splats fail to re-fetch as expected (re-drop to recover).

## Known limitations

- **Dropped files use `blob:` URLs that don't survive page reloads.** Saved scenes containing dropped splats fail to re-fetch their blob URLs after refresh. Workarounds: re-drop the file, or host the splat at a stable URL and use `?splat=https://...`. Persistence via IndexedDB is future work.
- **No depth sort yet** (Phase 3) — splats render in load order, which for SOG is Morton order. Still gives a recognizable scene; alpha blending is wrong for hidden-surface ordering.
- **`f_rest_*` (PLY) and `shN_*` (SOG)** higher-order SH bands are parsed/skipped, not rendered. View-dependent SH is Phase 1.5 / future.
- **ZIP reader** does not handle ZIP64 (>4 GB archives) — fine for SOG sizes seen in practice.

Refs: #16 (tracking).