### PR TITLE
shrink root main.js: extract 11 modules (314 KB → 143 KB / -54%)

### DIFF
--- a/src/debug/sceneDebug.js
+++ b/src/debug/sceneDebug.js
@@ -1,0 +1,524 @@
+// src/debug/sceneDebug.js
+// Extracted from main.js (chore/main-js-shrink-2). Owns the developer-only
+// debug overlays that drape the scene: raycast debug arrow + line, collision
+// shape preview meshes, gameplay-debug ray, force-all-shadows toggle, perf-mode
+// (DDGI / bloom / fog suspend) toggle, and shadow-debug status pane.
+
+import * as THREE from 'three';
+
+let scene, camera, renderer, sceneSystem, physics, physicsCore;
+let gameplay, importedPropState;
+let raycastDebugState, collisionDebugState, shadowDebugState;
+let shadowDebugUiRefs, perfModeUiRefs;
+let postProcessVolumeManager;
+let getVolumetricFogController, getDDGIManager;
+let VEHICLE_SETTINGS;
+let tempVectorC;
+let getActorByBodyId, getActorComponentFlags, getActorRenderObject;
+let physgunCameraRay, pushDebugConsoleLine;
+
+// Owned state — perf-mode toggle is a module-private variable, mutated by
+// setPerfModeEnabled. It was a top-level `let` in main.js; moving it here keeps
+// the toggle authoritative without main.js needing to reach across the boundary.
+let perfModeEnabled = false;
+
+export function installSceneDebug(deps) {
+    ({
+        scene, camera, renderer, sceneSystem, physics, physicsCore,
+        gameplay, importedPropState,
+        raycastDebugState, collisionDebugState, shadowDebugState,
+        shadowDebugUiRefs, perfModeUiRefs,
+        postProcessVolumeManager,
+        getVolumetricFogController, getDDGIManager,
+        VEHICLE_SETTINGS,
+        tempVectorC,
+        getActorByBodyId, getActorComponentFlags, getActorRenderObject,
+        physgunCameraRay, pushDebugConsoleLine,
+    } = deps);
+}
+
+export function ensureRaycastDebugLine() {
+    if (raycastDebugState.helper || !scene) return raycastDebugState.helper;
+
+    const helper = new THREE.ArrowHelper(
+        new THREE.Vector3(0, 0, -1),
+        new THREE.Vector3(),
+        1,
+        0xef4444,
+        0.35,
+        0.18,
+    );
+    helper.name = 'raycast-debug-line';
+    helper.renderOrder = 999;
+    helper.line.renderOrder = 999;
+    helper.cone.renderOrder = 999;
+    helper.line.material.depthTest = false;
+    helper.line.material.transparent = true;
+    helper.line.material.opacity = 0.95;
+    helper.line.material.toneMapped = false;
+    helper.cone.material.depthTest = false;
+    helper.cone.material.transparent = true;
+    helper.cone.material.opacity = 0.95;
+    helper.cone.material.toneMapped = false;
+    helper.visible = false;
+    scene.add(helper);
+
+    const hitMarker = new THREE.Mesh(
+        new THREE.SphereGeometry(0.08, 14, 10),
+        new THREE.MeshBasicMaterial({
+            color: 0xef4444,
+            transparent: true,
+            opacity: 0.95,
+            depthTest: false,
+            toneMapped: false,
+        })
+    );
+    hitMarker.name = 'raycast-debug-hit';
+    hitMarker.renderOrder = 1000;
+    hitMarker.visible = false;
+    scene.add(hitMarker);
+
+    raycastDebugState.helper = helper;
+    raycastDebugState.hitMarker = hitMarker;
+    return helper;
+}
+
+export function updateRaycastDebugLine(origin, direction, maxDist, hitPoint = null, hit = false) {
+    if (!raycastDebugState.enabled) {
+        return;
+    }
+
+    const helper = ensureRaycastDebugLine();
+    const distance = Number.isFinite(maxDist) && maxDist > 0 ? maxDist : 0;
+    const dx = Number(direction?.x);
+    const dy = Number(direction?.y);
+    const dz = Number(direction?.z);
+
+    if (!helper || !Number.isFinite(distance) || ![dx, dy, dz].every(Number.isFinite)) {
+        return;
+    }
+
+    raycastDebugState.points[0].set(
+        Number(origin?.x) || 0,
+        Number(origin?.y) || 0,
+        Number(origin?.z) || 0,
+    );
+
+    if (hitPoint && Number.isFinite(hitPoint.x) && Number.isFinite(hitPoint.y) && Number.isFinite(hitPoint.z)) {
+        raycastDebugState.points[1].set(hitPoint.x, hitPoint.y, hitPoint.z);
+    } else {
+        raycastDebugState.points[1].set(
+            raycastDebugState.points[0].x + dx * distance,
+            raycastDebugState.points[0].y + dy * distance,
+            raycastDebugState.points[0].z + dz * distance,
+        );
+    }
+
+    tempVectorC.subVectors(raycastDebugState.points[1], raycastDebugState.points[0]);
+    const length = tempVectorC.length();
+    if (length <= 1e-5) {
+        helper.visible = false;
+        if (raycastDebugState.hitMarker) {
+            raycastDebugState.hitMarker.visible = false;
+        }
+        return;
+    }
+
+    const visibleLength = Math.max(length, 1.25);
+    helper.position.copy(raycastDebugState.points[0]);
+    helper.setDirection(tempVectorC.normalize());
+    helper.setLength(
+        visibleLength,
+        Math.min(Math.max(visibleLength * 0.14, 0.25), 0.9),
+        Math.min(Math.max(visibleLength * 0.07, 0.12), 0.38),
+    );
+    helper.setColor(hit ? 0x22c55e : 0xef4444);
+    helper.visible = true;
+
+    if (raycastDebugState.hitMarker) {
+        raycastDebugState.hitMarker.position.copy(raycastDebugState.points[1]);
+        raycastDebugState.hitMarker.material.color.set(hit ? 0x22c55e : 0xef4444);
+        raycastDebugState.hitMarker.visible = true;
+    }
+    raycastDebugState.expiresAt = performance.now() + raycastDebugState.timeoutMs;
+}
+
+export function updateRaycasterDebugLine(ray, maxDist, hitPoint = null, hit = false) {
+    if (!ray) return;
+    updateRaycastDebugLine(ray.origin, ray.direction, maxDist, hitPoint, hit);
+}
+
+export function tickRaycastDebugLine() {
+    if (!raycastDebugState.helper?.visible) return;
+    if (performance.now() < raycastDebugState.expiresAt) return;
+    raycastDebugState.helper.visible = false;
+    if (raycastDebugState.hitMarker) {
+        raycastDebugState.hitMarker.visible = false;
+    }
+}
+
+export function createCollisionLineSegments(geometry, color) {
+    const edges = new THREE.EdgesGeometry(geometry, 30);
+    const lines = new THREE.LineSegments(
+        edges,
+        new THREE.LineBasicMaterial({
+            color,
+            depthTest: false,
+            transparent: true,
+            opacity: 0.9,
+            toneMapped: false,
+        })
+    );
+    lines.renderOrder = 995;
+    return lines;
+}
+
+export function createCollisionOverlayFromObject(sourceRoot, color) {
+    if (!sourceRoot) return null;
+
+    const overlayRoot = sourceRoot.isMesh && sourceRoot.geometry
+        ? createCollisionLineSegments(sourceRoot.geometry, color)
+        : new THREE.Group();
+    const sourceMap = new Map([[sourceRoot, overlayRoot]]);
+
+    sourceRoot.traverse((source) => {
+        const overlayParent = sourceMap.get(source);
+        if (!overlayParent) return;
+
+        source.children.forEach((child) => {
+            let overlayChild;
+            if (child.isMesh && child.geometry) {
+                overlayChild = createCollisionLineSegments(child.geometry, color);
+            } else {
+                overlayChild = new THREE.Group();
+            }
+
+            overlayChild.position.copy(child.position);
+            overlayChild.quaternion.copy(child.quaternion);
+            overlayChild.scale.copy(child.scale);
+            overlayParent.add(overlayChild);
+            sourceMap.set(child, overlayChild);
+        });
+    });
+
+    return overlayRoot;
+}
+
+export function createImportedSimpleCollisionOverlay(template, color) {
+    if (!template?.root) return null;
+
+    template.root.updateWorldMatrix(true, true);
+    const bounds = new THREE.Box3().setFromObject(template.root);
+    const size = bounds.getSize(new THREE.Vector3());
+    const center = bounds.getCenter(new THREE.Vector3());
+    const lines = createCollisionLineSegments(
+        new THREE.BoxGeometry(
+            Math.max(size.x, 0.16),
+            Math.max(size.y, 0.16),
+            Math.max(size.z, 0.16),
+        ),
+        color,
+    );
+    lines.position.copy(center);
+    return lines;
+}
+
+export function buildActorCollisionOverlay(actor) {
+    const flags = getActorComponentFlags(actor);
+    if (!flags.collision) return null;
+
+    const actorMesh = getActorRenderObject(actor);
+    if (!actorMesh) return null;
+
+    const color = flags.physics ? 0x22c55e : 0xf59e0b;
+
+    if (actor.kind === 'vehicle') {
+        return createCollisionLineSegments(
+            new THREE.BoxGeometry(VEHICLE_SETTINGS.width, VEHICLE_SETTINGS.height, VEHICLE_SETTINGS.length),
+            color,
+        );
+    }
+
+    if (actor.kind === 'imported') {
+        const template = importedPropState.templates.find((entry) => entry.id === actor.templateId);
+        if (template?.collisionMode === 'simple') {
+            return createImportedSimpleCollisionOverlay(template, color);
+        }
+        return createCollisionOverlayFromObject(actorMesh, color);
+    }
+
+    return createCollisionOverlayFromObject(actorMesh, color);
+}
+
+export function disposeCollisionOverlayObject(object) {
+    if (!object) return;
+    object.traverse((child) => {
+        if (child.geometry) {
+            child.geometry.dispose?.();
+        }
+        const material = child.material;
+        if (Array.isArray(material)) {
+            material.forEach((entry) => entry?.dispose?.());
+        } else {
+            material?.dispose?.();
+        }
+    });
+}
+
+export function clearCollisionDebugOverlays() {
+    collisionDebugState.overlays.forEach((overlay) => {
+        overlay.parent?.remove(overlay);
+        disposeCollisionOverlayObject(overlay);
+    });
+    collisionDebugState.overlays = [];
+}
+
+export function refreshCollisionDebugOverlays() {
+    if (!collisionDebugState.enabled || !scene) {
+        clearCollisionDebugOverlays();
+        return;
+    }
+
+    clearCollisionDebugOverlays();
+
+    for (const actor of sceneSystem?.actors || []) {
+        const actorMesh = getActorRenderObject(actor);
+        const overlay = buildActorCollisionOverlay(actor);
+        if (!overlay || !actorMesh) continue;
+
+        overlay.name = 'collision-debug-overlay';
+        actorMesh.add(overlay);
+        collisionDebugState.overlays.push(overlay);
+    }
+}
+
+export function setCollisionDebugEnabled(isEnabled) {
+    collisionDebugState.enabled = !!isEnabled;
+    refreshCollisionDebugOverlays();
+    pushDebugConsoleLine(`Collision overlay ${collisionDebugState.enabled ? 'enabled' : 'disabled'} (F8).`, 'success');
+}
+
+export function raycastWorld(origin, direction, maxDist = 1000) {
+    if (!physicsCore?.castRay) return { hit: false };
+    const distance = Number(maxDist);
+    const safeDistance = Number.isFinite(distance) && distance > 0 ? distance : 1000;
+    const result = physicsCore.castRay(origin, direction, safeDistance);
+    updateRaycastDebugLine(origin, direction, safeDistance, result?.point ?? null, !!result?.hit);
+    if (!result?.hit) return { hit: false };
+    return { ...result, actor: getActorByBodyId(result.bodyId) };
+}
+
+export function describeRaycastHit(result) {
+    if (!result?.hit) {
+        return {
+            key: 'miss',
+            message: 'Debug ray hit nothing.',
+        };
+    }
+
+    const actor = result.actor ?? null;
+    const actorLabel = actor?.userData?.label || actor?.rootNode?.name || actor?.name || actor?.id || '';
+    const kind = actor?.kind || 'world-static';
+    const distance = Number.isFinite(result.distance) ? result.distance.toFixed(2) : 'unknown';
+    const targetLabel = actorLabel || `body ${result.bodyId ?? 'unknown'}`;
+
+    return {
+        key: `${actor?.id || 'world-static'}:${distance}`,
+        message: `Debug ray hit ${targetLabel} (${kind}) at ${distance}m.`,
+    };
+}
+
+export function logGameplayDebugRayHit(result) {
+    if (!raycastDebugState.enabled) {
+        return;
+    }
+
+    const description = describeRaycastHit(result);
+    if (description.key === raycastDebugState.lastConsoleHitKey) {
+        return;
+    }
+
+    raycastDebugState.lastConsoleHitKey = description.key;
+    console.log(description.message, result);
+}
+
+export function updateGameplayDebugRay() {
+    if (!raycastDebugState.enabled || !gameplay.active || !camera) {
+        if (raycastDebugState.helper) {
+            raycastDebugState.helper.visible = false;
+        }
+        if (raycastDebugState.hitMarker) {
+            raycastDebugState.hitMarker.visible = false;
+        }
+        raycastDebugState.lastConsoleHitKey = '';
+        return;
+    }
+
+    const { origin, direction } = physgunCameraRay();
+    const result = raycastWorld(origin, direction, 50);
+    logGameplayDebugRayHit(result);
+}
+
+export function setRayDebugEnabled(isEnabled) {
+    raycastDebugState.enabled = !!isEnabled;
+    raycastDebugState.lastConsoleHitKey = '';
+
+    if (!raycastDebugState.enabled) {
+        if (raycastDebugState.helper) {
+            raycastDebugState.helper.visible = false;
+        }
+        if (raycastDebugState.hitMarker) {
+            raycastDebugState.hitMarker.visible = false;
+        }
+    }
+}
+
+export function formatShadowDebugStatus() {
+    const lastPassSuffix = shadowDebugState.lastAppliedAt > 0
+        ? ` Last pass hit ${shadowDebugState.lastMeshCount} mesh${shadowDebugState.lastMeshCount === 1 ? '' : 'es'}, changed ${shadowDebugState.lastUpdatedCount}, armed ${shadowDebugState.lastLightCount} shadow light${shadowDebugState.lastLightCount === 1 ? '' : 's'}.`
+        : '';
+
+    if (shadowDebugState.forceAllMeshes) {
+        return `Auto force is on. New scene meshes get swept every ${Math.round(shadowDebugState.autoApplyIntervalMs)} ms.${lastPassSuffix}`;
+    }
+
+    if (shadowDebugState.lastAppliedAt > 0) {
+        return `Auto force is off.${lastPassSuffix}`;
+    }
+
+    return 'Auto force is off. Apply Now runs one scene-wide shadow pass without keeping it enabled.';
+}
+
+export function updateShadowDebugUi() {
+    if (!shadowDebugUiRefs) return;
+
+    shadowDebugUiRefs.forceOffBtn?.classList.toggle('viewer-toggle-btn-active', !shadowDebugState.forceAllMeshes);
+    shadowDebugUiRefs.forceOnBtn?.classList.toggle('viewer-toggle-btn-active', shadowDebugState.forceAllMeshes);
+
+    if (shadowDebugUiRefs.status) {
+        shadowDebugUiRefs.status.textContent = formatShadowDebugStatus();
+    }
+}
+
+export function isShadowForceExcludedObject(object) {
+    let current = object;
+    while (current) {
+        if (current.userData?.ignoreForcedSceneShadows) {
+            return true;
+        }
+        current = current.parent ?? null;
+    }
+
+    return object?.name === 'tire-skid-ribbon';
+}
+
+export function forceAllSceneMeshShadows() {
+    if (!scene?.traverse) {
+        shadowDebugState.lastAppliedAt = performance.now();
+        shadowDebugState.lastMeshCount = 0;
+        shadowDebugState.lastUpdatedCount = 0;
+        shadowDebugState.lastLightCount = 0;
+        updateShadowDebugUi();
+        return {
+            meshCount: 0,
+            updatedCount: 0,
+            shadowLightCount: 0,
+        };
+    }
+
+    let meshCount = 0;
+    let updatedCount = 0;
+    let shadowLightCount = 0;
+
+    scene.traverse((object) => {
+        if (!object) return;
+
+        if (object.isMesh) {
+            if (isShadowForceExcludedObject(object)) {
+                return;
+            }
+
+            meshCount += 1;
+
+            if (!object.castShadow || !object.receiveShadow) {
+                updatedCount += 1;
+            }
+
+            object.castShadow = true;
+            object.receiveShadow = true;
+            return;
+        }
+
+        if (object.isDirectionalLight || object.isSpotLight || object.isPointLight) {
+            if (!object.castShadow) {
+                shadowLightCount += 1;
+            }
+            object.castShadow = true;
+        }
+    });
+
+    if (renderer?.shadowMap) {
+        renderer.shadowMap.enabled = true;
+    }
+
+    shadowDebugState.lastAppliedAt = performance.now();
+    shadowDebugState.lastMeshCount = meshCount;
+    shadowDebugState.lastUpdatedCount = updatedCount;
+    shadowDebugState.lastLightCount = shadowLightCount;
+    updateShadowDebugUi();
+
+    return {
+        meshCount,
+        updatedCount,
+        shadowLightCount,
+    };
+}
+
+export function setForceAllSceneMeshShadowsEnabled(isEnabled) {
+    shadowDebugState.forceAllMeshes = !!isEnabled;
+    const result = shadowDebugState.forceAllMeshes ? forceAllSceneMeshShadows() : null;
+    updateShadowDebugUi();
+    return result;
+}
+
+export function updatePerfModeUi() {
+    if (!perfModeUiRefs) return;
+    perfModeUiRefs.offBtn?.classList.toggle('viewer-toggle-btn-active', !perfModeEnabled);
+    perfModeUiRefs.onBtn?.classList.toggle('viewer-toggle-btn-active', perfModeEnabled);
+    if (perfModeUiRefs.status) {
+        perfModeUiRefs.status.textContent = perfModeEnabled
+            ? 'Performance mode on. DDGI, volumetric fog, and post-process bloom are paused.'
+            : 'Performance mode off. Full DDGI + fog + post-process active.';
+    }
+}
+
+export function setPerfModeEnabled(isEnabled) {
+    const next = !!isEnabled;
+    if (perfModeEnabled === next) {
+        updatePerfModeUi();
+        return;
+    }
+    perfModeEnabled = next;
+
+    // Volumetric fog: hides the layer group AND clears scene.fog when off.
+    getVolumetricFogController()?.setEnabled(!perfModeEnabled);
+
+    // DDGI: tick() short-circuits when state.enabled is false; injectionEnabled
+    // controls the shader-injection patching loop, which we also pause so
+    // newly-added materials don't get patched while perf mode is on.
+    const ddgi = getDDGIManager();
+    ddgi?.setEnabled(!perfModeEnabled);
+    ddgi?.setInjectionEnabled(!perfModeEnabled);
+
+    // Post-process: clamps bloom uniforms to neutral so the MRT bloom pass
+    // becomes a no-op while still running (cheap once strength is 0).
+    postProcessVolumeManager?.setEnabled(!perfModeEnabled);
+
+    updatePerfModeUi();
+}
+
+export function tickForceAllSceneMeshShadows() {
+    if (!shadowDebugState.forceAllMeshes) return;
+    if ((performance.now() - shadowDebugState.lastAppliedAt) < shadowDebugState.autoApplyIntervalMs) return;
+    forceAllSceneMeshShadows();
+}

--- a/src/editor/sceneUi.js
+++ b/src/editor/sceneUi.js
@@ -1,0 +1,833 @@
+// src/editor/sceneUi.js
+// Extracted from main.js (chore/main-js-shrink-2). Holds three editor surfaces:
+//   1. Post-process volume UI (formatPostProcessValue … applyPostProcessSettingsFromUi)
+//   2. Actor / blueprint editor side-panel (syncActorEditor* / openActorEditor / spawnActorFromEditor)
+//   3. World environment ("Sky / Sun / Ambient / Bloom / Fog") panel (loadWorldEnvFromStorage … resetWorldEnvDefaults)
+//      + the master scene-list refresh (refreshSceneUI / createSceneActorItem).
+//
+// Late-init refs (ambientLight, hemiLight, mainDirectionalLight, ddgiVolume,
+// volumetricFogController) come through as getters because they are assigned in
+// init() AFTER wireExtractedModules runs.
+
+import * as THREE from 'three';
+import gsap from 'gsap';
+
+// State + DOM refs (snapshot at wire time — these are populated earlier in init)
+let gameplay, blueprintState, objectScriptState, importedPropState;
+let physics, collisionDebugState, mobileState;
+let camera, renderer, scene, sceneSystem;
+let transformControl;
+let actorEditor, actorEditorSummary, actorEditorStatus;
+let actorKindSelect, actorLabelInput, actorScaleInput;
+let actorImportedTemplateSelect, actorVehicleBodyTemplateSelect, actorVehicleWheelTemplateSelect;
+let actorComponentCollisionInput, actorComponentPhysicsInput, actorComponentScriptsInput;
+let actorEditorState;
+let setPendingVehicleTemplateImportSlot, vehicleTemplateImportInput;
+let postProcessUiRefs, postProcessUiState, postProcessVolumeManager;
+let globalPostProcessUniforms;
+let worldEnvUiRefs, worldEnvState;
+let WORLD_ENV_DEFAULTS, WORLD_ENV_STORAGE_KEY, VEHICLE_CUSTOM_IMPORT_VALUE;
+let sceneUiCount, sceneUiList;
+
+// Late-init refs (getters)
+let getAmbientLight, getHemiLight, getMainDirectionalLight;
+let getDdgiVolume, getVolumetricFogController, getEnvironmentController;
+
+// External functions
+let switchEnvironment;
+let getDDGIManager;
+let actorInheritsCore, getActorCoreSource, getActorRenderObject;
+let ensureActorScriptState;
+let selectShowcaseActor, focusSceneActor;
+let enterBlueprintEditor, openObjectScriptEditor;
+let spawnImportedProp, spawnDrivableCar, spawnDynamicPrimitive, spawnDDGIVolumeActor;
+let exportActorToFile;
+let syncBlueprintPhysicsEditor, syncShowcaseAnglesFromTarget, applyShowcaseCameraRotation;
+let refreshCollisionDebugOverlays;
+
+export function installSceneUi(deps) {
+    ({
+        gameplay, blueprintState, objectScriptState, importedPropState,
+        physics, collisionDebugState, mobileState,
+        camera, renderer, scene, sceneSystem,
+        transformControl,
+        actorEditor, actorEditorSummary, actorEditorStatus,
+        actorKindSelect, actorLabelInput, actorScaleInput,
+        actorImportedTemplateSelect, actorVehicleBodyTemplateSelect, actorVehicleWheelTemplateSelect,
+        actorComponentCollisionInput, actorComponentPhysicsInput, actorComponentScriptsInput,
+        actorEditorState,
+        setPendingVehicleTemplateImportSlot, vehicleTemplateImportInput,
+        postProcessUiRefs, postProcessUiState, postProcessVolumeManager,
+        globalPostProcessUniforms,
+        worldEnvUiRefs, worldEnvState,
+        WORLD_ENV_DEFAULTS, WORLD_ENV_STORAGE_KEY, VEHICLE_CUSTOM_IMPORT_VALUE,
+        sceneUiCount, sceneUiList,
+        getAmbientLight, getHemiLight, getMainDirectionalLight,
+        getDdgiVolume, getVolumetricFogController, getEnvironmentController,
+        switchEnvironment,
+        getDDGIManager,
+        actorInheritsCore, getActorCoreSource, getActorRenderObject,
+        ensureActorScriptState,
+        selectShowcaseActor, focusSceneActor,
+        enterBlueprintEditor, openObjectScriptEditor,
+        spawnImportedProp, spawnDrivableCar, spawnDynamicPrimitive, spawnDDGIVolumeActor,
+        exportActorToFile,
+        syncBlueprintPhysicsEditor, syncShowcaseAnglesFromTarget, applyShowcaseCameraRotation,
+        refreshCollisionDebugOverlays,
+    } = deps);
+}
+
+export function formatPostProcessValue(value, digits = 2) {
+    return Number.isFinite(value) ? value.toFixed(digits) : '--';
+}
+
+export function clampPostProcessInput(value, fallback, min, max) {
+    const numericValue = Number.isFinite(value) ? value : fallback;
+    return THREE.MathUtils.clamp(numericValue, min, max);
+}
+
+export function readPostProcessInputValue(element, fallback, min, max) {
+    const numericValue = Number.parseFloat(element?.value ?? '');
+    return clampPostProcessInput(numericValue, fallback, min, max);
+}
+
+export function updatePostProcessSliderLabels() {
+    const refs = postProcessUiRefs;
+    if (!refs) return;
+
+    if (refs.exposureValue) refs.exposureValue.textContent = formatPostProcessValue(Number.parseFloat(refs.exposureInput?.value ?? '1'), 2);
+    if (refs.bloomStrengthValue) refs.bloomStrengthValue.textContent = formatPostProcessValue(Number.parseFloat(refs.bloomStrengthInput?.value ?? '1.25'), 2);
+    if (refs.bloomRadiusValue) refs.bloomRadiusValue.textContent = formatPostProcessValue(Number.parseFloat(refs.bloomRadiusInput?.value ?? '0.95'), 2);
+    if (refs.bloomThresholdValue) refs.bloomThresholdValue.textContent = formatPostProcessValue(Number.parseFloat(refs.bloomThresholdInput?.value ?? '0.48'), 2);
+    if (refs.blendSpeedValue) refs.blendSpeedValue.textContent = formatPostProcessValue(Number.parseFloat(refs.blendSpeedInput?.value ?? '2.5'), 1);
+}
+
+export function updatePostProcessToggleUi() {
+    const refs = postProcessUiRefs;
+    if (!refs) return;
+
+    const editingVolume = postProcessUiState.target === 'volume';
+    refs.targetGlobalBtn?.classList.toggle('viewer-toggle-btn-active', !editingVolume);
+    refs.targetVolumeBtn?.classList.toggle('viewer-toggle-btn-active', editingVolume);
+
+    refs.priorityInput.disabled = !editingVolume;
+    refs.sizeXInput.disabled = !editingVolume;
+    refs.sizeYInput.disabled = !editingVolume;
+    refs.sizeZInput.disabled = !editingVolume;
+}
+
+export function updatePostProcessStatusUi() {
+    const refs = postProcessUiRefs;
+    if (!refs?.status) return;
+
+    const snapshot = postProcessVolumeManager?.getSnapshot?.();
+    if (!snapshot) {
+        refs.status.textContent = 'Post processing is not ready yet.';
+        return;
+    }
+
+    const editorVolume = snapshot.editorVolume;
+    const current = snapshot.currentSettings;
+    const modeLabel = postProcessUiState.target === 'volume' ? 'Editing volume override.' : 'Editing global defaults.';
+
+    if (!editorVolume) {
+        refs.status.textContent = `${modeLabel} No box volume placed yet. Active exposure ${formatPostProcessValue(current.toneMappingExposure, 2)}, bloom ${formatPostProcessValue(current.bloomStrength, 2)} / ${formatPostProcessValue(current.bloomRadius, 2)} / ${formatPostProcessValue(current.bloomThreshold, 2)}.`;
+        return;
+    }
+
+    const size = editorVolume.size;
+    refs.status.textContent = `${modeLabel} 1 volume live. Size ${formatPostProcessValue(size.x, 1)} x ${formatPostProcessValue(size.y, 1)} x ${formatPostProcessValue(size.z, 1)}, priority ${editorVolume.priority}. Active exposure ${formatPostProcessValue(current.toneMappingExposure, 2)}, bloom ${formatPostProcessValue(current.bloomStrength, 2)} / ${formatPostProcessValue(current.bloomRadius, 2)} / ${formatPostProcessValue(current.bloomThreshold, 2)}.`;
+}
+
+export function loadPostProcessInputsFromState() {
+    const refs = postProcessUiRefs;
+    if (!refs) return;
+
+    const snapshot = postProcessVolumeManager?.getSnapshot?.();
+    const defaults = snapshot?.defaultSettings ?? {
+        bloomStrength: globalPostProcessUniforms.bloomStrength.value,
+        bloomRadius: globalPostProcessUniforms.bloomRadius.value,
+        bloomThreshold: globalPostProcessUniforms.bloomThreshold.value,
+        toneMappingExposure: renderer?.toneMappingExposure ?? 1.0,
+        priority: 0,
+    };
+    const editorVolume = snapshot?.editorVolume;
+    const volumeSettings = editorVolume?.settings ?? defaults;
+    const selectedSettings = postProcessUiState.target === 'volume' ? volumeSettings : defaults;
+
+    if (refs.exposureInput) refs.exposureInput.value = formatPostProcessValue(selectedSettings.toneMappingExposure, 2);
+    if (refs.bloomStrengthInput) refs.bloomStrengthInput.value = formatPostProcessValue(selectedSettings.bloomStrength, 2);
+    if (refs.bloomRadiusInput) refs.bloomRadiusInput.value = formatPostProcessValue(selectedSettings.bloomRadius, 2);
+    if (refs.bloomThresholdInput) refs.bloomThresholdInput.value = formatPostProcessValue(selectedSettings.bloomThreshold, 2);
+    if (refs.blendSpeedInput) refs.blendSpeedInput.value = formatPostProcessValue(snapshot?.transitionSpeed ?? 2.5, 1);
+    if (refs.priorityInput) refs.priorityInput.value = String(Math.round(volumeSettings.priority ?? 0));
+    if (refs.sizeXInput) refs.sizeXInput.value = formatPostProcessValue(editorVolume?.size.x ?? 12, 1);
+    if (refs.sizeYInput) refs.sizeYInput.value = formatPostProcessValue(editorVolume?.size.y ?? 6, 1);
+    if (refs.sizeZInput) refs.sizeZInput.value = formatPostProcessValue(editorVolume?.size.z ?? 12, 1);
+
+    if (refs.placeVolumeBtn) refs.placeVolumeBtn.textContent = editorVolume ? 'Move To Camera' : 'Place At Camera';
+    if (refs.removeVolumeBtn) refs.removeVolumeBtn.disabled = !editorVolume;
+    if (refs.toggleBoundsBtn) {
+        refs.toggleBoundsBtn.textContent = snapshot?.debugVisible ? 'Hide Bounds' : 'Show Bounds';
+        refs.toggleBoundsBtn.classList.toggle('viewer-toggle-btn-active', !!snapshot?.debugVisible);
+    }
+
+    updatePostProcessSliderLabels();
+}
+
+export function syncPostProcessVolumeUi({ reloadInputs = true } = {}) {
+    updatePostProcessToggleUi();
+    if (reloadInputs) {
+        loadPostProcessInputsFromState();
+    } else {
+        updatePostProcessSliderLabels();
+    }
+    updatePostProcessStatusUi();
+}
+
+export function applyPostProcessSettingsFromUi({ createVolumeIfNeeded = false, placeVolumeAtCamera = false, reloadInputs = false } = {}) {
+    const refs = postProcessUiRefs;
+    const manager = postProcessVolumeManager;
+    if (!refs || !manager) return;
+
+    const settings = {
+        toneMappingExposure: readPostProcessInputValue(refs.exposureInput, 1.0, 0.1, 2.5),
+        bloomStrength: readPostProcessInputValue(refs.bloomStrengthInput, 1.25, 0, 3),
+        bloomRadius: readPostProcessInputValue(refs.bloomRadiusInput, 0.95, 0, 2),
+        bloomThreshold: readPostProcessInputValue(refs.bloomThresholdInput, 0.48, 0, 2),
+        priority: Math.round(readPostProcessInputValue(refs.priorityInput, 0, -100, 100)),
+    };
+    const transitionSpeed = readPostProcessInputValue(refs.blendSpeedInput, 2.5, 0.1, 10);
+    manager.setTransitionSpeed?.(transitionSpeed);
+
+    if (postProcessUiState.target === 'volume') {
+        const snapshot = manager.getSnapshot?.();
+        const existingVolume = snapshot?.editorVolume ?? null;
+        const size = new THREE.Vector3(
+            readPostProcessInputValue(refs.sizeXInput, 12, 0.5, 512),
+            readPostProcessInputValue(refs.sizeYInput, 6, 0.5, 512),
+            readPostProcessInputValue(refs.sizeZInput, 12, 0.5, 512)
+        );
+
+        if (existingVolume || createVolumeIfNeeded || placeVolumeAtCamera) {
+            const position = placeVolumeAtCamera || !existingVolume
+                ? (camera?.position?.clone?.() ?? new THREE.Vector3())
+                : existingVolume.position;
+            manager.ensureEditorVolume?.({ position, size, settings });
+            if (placeVolumeAtCamera) {
+                manager.setDebugVisible?.(true);
+            }
+        }
+    } else {
+        manager.setDefaultSettings?.(settings);
+    }
+
+    manager.update?.(1);
+    syncPostProcessVolumeUi({ reloadInputs });
+}
+
+export function syncActorEditorTemplateOptions(selectedTemplateId = '', selectedVehicleBodyTemplateId = '', selectedVehicleWheelTemplateId = '') {
+    if (actorImportedTemplateSelect) {
+        actorImportedTemplateSelect.innerHTML = '';
+
+        if (!importedPropState.templates.length) {
+            const option = document.createElement('option');
+            option.value = '';
+            option.textContent = 'No imported source available';
+            actorImportedTemplateSelect.appendChild(option);
+            actorImportedTemplateSelect.value = '';
+        } else {
+            importedPropState.templates.forEach((template) => {
+                const option = document.createElement('option');
+                option.value = template.id;
+                option.textContent = `${template.displayName} (${template.collisionMode})`;
+                actorImportedTemplateSelect.appendChild(option);
+            });
+
+            actorImportedTemplateSelect.value = selectedTemplateId && importedPropState.templates.some((template) => template.id === selectedTemplateId)
+                ? selectedTemplateId
+                : importedPropState.templates[0].id;
+        }
+    }
+
+    const populateVehicleSelect = (select, selectedId, defaultLabel) => {
+        if (!select) return;
+        select.innerHTML = '';
+        const defaultOption = document.createElement('option');
+        defaultOption.value = '';
+        defaultOption.textContent = defaultLabel;
+        select.appendChild(defaultOption);
+        importedPropState.templates.forEach((template) => {
+            const option = document.createElement('option');
+            option.value = template.id;
+            option.textContent = template.displayName;
+            select.appendChild(option);
+        });
+        const customOption = document.createElement('option');
+        customOption.value = VEHICLE_CUSTOM_IMPORT_VALUE;
+        customOption.textContent = 'Custom… (import file)';
+        select.appendChild(customOption);
+        select.value = selectedId && importedPropState.templates.some((template) => template.id === selectedId)
+            ? selectedId
+            : '';
+    };
+    populateVehicleSelect(actorVehicleBodyTemplateSelect, selectedVehicleBodyTemplateId, 'Default Sedan');
+    populateVehicleSelect(actorVehicleWheelTemplateSelect, selectedVehicleWheelTemplateId, 'Default Wheel');
+}
+
+export function handleVehicleTemplateSelectChange(slot) {
+    const select = slot === 'body' ? actorVehicleBodyTemplateSelect : actorVehicleWheelTemplateSelect;
+    if (!select) return;
+
+    if (select.value === VEHICLE_CUSTOM_IMPORT_VALUE) {
+        // Reset visible value back to default so the dropdown doesn't get
+        // stuck on "Custom…" if the user cancels the file picker.
+        select.value = '';
+        if (!vehicleTemplateImportInput) return;
+        setPendingVehicleTemplateImportSlot(slot);
+        vehicleTemplateImportInput.value = '';
+        vehicleTemplateImportInput.click();
+        return;
+    }
+
+    syncActorEditorUi();
+}
+
+export function syncActorEditorUi() {
+    if (!actorKindSelect || !actorEditorSummary || !actorEditorStatus || !actorImportedTemplateSelect || !actorComponentCollisionInput || !actorComponentPhysicsInput || !actorComponentScriptsInput) {
+        return;
+    }
+
+    const kind = actorKindSelect.value || 'sphere';
+    const isImported = kind === 'imported';
+    const isVehicle = kind === 'vehicle';
+
+    actorImportedTemplateSelect.disabled = !isImported;
+    if (actorVehicleBodyTemplateSelect) {
+        actorVehicleBodyTemplateSelect.disabled = !isVehicle;
+    }
+    if (actorVehicleWheelTemplateSelect) {
+        actorVehicleWheelTemplateSelect.disabled = !isVehicle;
+    }
+    actorComponentCollisionInput.disabled = isVehicle;
+    actorComponentPhysicsInput.disabled = isVehicle || !actorComponentCollisionInput.checked;
+    if (isVehicle) {
+        actorComponentCollisionInput.checked = true;
+        actorComponentPhysicsInput.checked = true;
+    } else if (!actorComponentCollisionInput.checked) {
+        actorComponentPhysicsInput.checked = false;
+    }
+
+    const typeLabel = kind === 'vehicle'
+        ? 'Vehicle Actor'
+        : kind === 'imported'
+            ? 'Imported Actor'
+            : kind === 'sphere'
+                ? 'Sphere Actor'
+                : 'Cube Actor';
+
+    actorEditorSummary.textContent = `Type: ${typeLabel}`;
+
+    if (isImported && !importedPropState.templates.length) {
+        actorEditorStatus.textContent = 'Import a prop source first, then create an imported actor instance from it.';
+        return;
+    }
+
+    const bodyDescription = !actorComponentCollisionInput.checked
+        ? ''
+        : actorComponentPhysicsInput.checked
+            ? ', simulated collision + physics'
+            : ', static collision only';
+    actorEditorStatus.textContent = `${typeLabel} will spawn with a render node${bodyDescription}${actorComponentScriptsInput.checked ? ', and a script host' : ''}.`;
+}
+
+export function closeActorEditor() {
+    actorEditorState.open = false;
+    if (actorEditor) {
+        actorEditor.hidden = true;
+    }
+}
+
+export function openActorEditor({ kind = 'cube', templateId = '', label = '', vehicleBodyTemplateId = '', vehicleWheelTemplateId = '' } = {}) {
+    if (!actorEditor) return;
+
+    actorEditorState.open = true;
+    if (actorKindSelect) {
+        actorKindSelect.value = kind;
+    }
+    if (actorLabelInput) {
+        actorLabelInput.value = label;
+    }
+    if (actorScaleInput) {
+        actorScaleInput.value = kind === 'cube' ? '2.0' : '0.5';
+    }
+    const actorColorEnabledReset = document.getElementById('actor-color-enabled');
+    const actorColorInputReset = document.getElementById('actor-color-input');
+    if (actorColorEnabledReset) actorColorEnabledReset.checked = false;
+    if (actorColorInputReset) actorColorInputReset.disabled = true;
+    if (actorComponentCollisionInput) {
+        actorComponentCollisionInput.checked = true;
+    }
+    if (actorComponentPhysicsInput) {
+        actorComponentPhysicsInput.checked = true;
+    }
+    if (actorComponentScriptsInput) {
+        actorComponentScriptsInput.checked = true;
+    }
+
+    syncActorEditorTemplateOptions(templateId, vehicleBodyTemplateId, vehicleWheelTemplateId);
+    syncActorEditorUi();
+    actorEditor.hidden = false;
+}
+
+export function spawnActorFromEditor({ openScriptEditor = false } = {}) {
+    const kind = actorKindSelect?.value || 'sphere';
+    const includeCollisionBody = kind === 'vehicle' ? true : !!actorComponentCollisionInput?.checked;
+    const simulatePhysics = kind === 'vehicle' ? true : !!actorComponentPhysicsInput?.checked;
+    const includeScripts = !!actorComponentScriptsInput?.checked;
+    const parsedScale = Number.parseFloat(actorScaleInput?.value ?? '0.5');
+    const scale = Number.isFinite(parsedScale) && parsedScale > 0 ? parsedScale : (kind === 'cube' ? 0.3 : 0.5);
+    const displayName = actorLabelInput?.value?.trim() || '';
+    const userData = displayName ? { label: displayName } : undefined;
+    let actor = null;
+
+    if (kind === 'vehicle') {
+        const bodyTemplateId = actorVehicleBodyTemplateSelect?.value || '';
+        const wheelTemplateId = actorVehicleWheelTemplateSelect?.value || '';
+        actor = spawnDrivableCar({ includeScripts, userData, bodyTemplateId, wheelTemplateId });
+    } else if (kind === 'ddgiVolume') {
+        actor = spawnDDGIVolumeActor({ userData });
+    } else if (kind === 'imported') {
+        const templateId = actorImportedTemplateSelect?.value || '';
+        if (!templateId) {
+            syncActorEditorUi();
+            return null;
+        }
+
+        actor = spawnImportedProp(templateId, {
+            includeCollisionBody,
+            simulatePhysics,
+            includeScripts,
+            userData,
+        });
+    } else {
+        actor = spawnDynamicPrimitive(kind, undefined, scale, {
+            includeCollisionBody,
+            simulatePhysics,
+            includeScripts,
+            userData,
+            returnActor: true,
+        });
+    }
+
+    if (!actor) {
+        if (actorEditorStatus) {
+            actorEditorStatus.textContent = 'Actor creation failed.';
+        }
+        return null;
+    }
+
+    const actorColorInput = document.getElementById('actor-color-input');
+    const actorColorEnabled = document.getElementById('actor-color-enabled');
+    if (actorColorInput && actorColorEnabled?.checked) {
+        setActorColor(actor, actorColorInput.value);
+    }
+
+    closeActorEditor();
+
+    if (openScriptEditor) {
+        ensureActorScriptState(actor);
+        selectShowcaseActor(actor.id);
+        openObjectScriptEditor('tick');
+    }
+
+    return actor;
+}
+
+export function loadWorldEnvFromStorage() {
+    try {
+        const raw = localStorage.getItem(WORLD_ENV_STORAGE_KEY);
+        if (!raw) return;
+        const parsed = JSON.parse(raw);
+        // Shallow-merge each section so we don't lose newly-added defaults
+        // when an older saved blob is read.
+        for (const key of Object.keys(WORLD_ENV_DEFAULTS)) {
+            if (parsed[key] && typeof parsed[key] === 'object') {
+                worldEnvState[key] = { ...WORLD_ENV_DEFAULTS[key], ...parsed[key] };
+            }
+        }
+    } catch (e) {
+        // Corrupt storage — fall back to defaults silently.
+    }
+}
+
+export function saveWorldEnvToStorage() {
+    try {
+        localStorage.setItem(WORLD_ENV_STORAGE_KEY, JSON.stringify(worldEnvState));
+    } catch (e) { /* private mode / quota — ignore */ }
+}
+
+export function applyWorldEnvState({ persist = true, switchSky = true } = {}) {
+    const s = worldEnvState;
+
+    // Sky / Background
+    if (getEnvironmentController()) {
+        getEnvironmentController().setEnabled?.(s.sky.enabled);
+        getEnvironmentController().setBackgroundBlurriness?.(s.sky.blurriness);
+        if (switchSky && getEnvironmentController().getCurrentEnvironment?.() !== s.sky.preset) {
+            getEnvironmentController().switchEnvironment?.(s.sky.preset);
+        }
+    }
+
+    // Ambient + Hemi + Sun — direct property writes since they're THREE lights.
+    if (getAmbientLight()) {
+        getAmbientLight().visible = s.ambient.enabled;
+        getAmbientLight().intensity = s.ambient.intensity;
+    }
+    if (getHemiLight()) {
+        getHemiLight().visible = s.hemi.enabled;
+        getHemiLight().intensity = s.hemi.intensity;
+    }
+    if (getMainDirectionalLight()) {
+        getMainDirectionalLight().visible = s.sun.enabled;
+        getMainDirectionalLight().castShadow = s.sun.enabled && s.sun.castShadow;
+        getMainDirectionalLight().intensity = s.sun.intensity;
+    }
+
+    // Tonemap exposure — write to renderer immediately AND record as the
+    // post-process volume default so the lerp doesn't drag it back.
+    if (renderer) {
+        renderer.toneMappingExposure = s.tonemap.exposure;
+    }
+    postProcessVolumeManager?.setDefaultSettings?.({ toneMappingExposure: s.tonemap.exposure });
+
+    // Bloom — when off, postProcessVolumeManager.setEnabled clamps uniforms
+    // to neutral. When on, push the user's slider values through both the
+    // shader uniforms AND the volume defaults so volume-based grading still works.
+    if (s.bloom.enabled) {
+        postProcessVolumeManager?.setEnabled?.(true);
+        if (globalPostProcessUniforms.bloomStrength) globalPostProcessUniforms.bloomStrength.value = s.bloom.strength;
+        if (globalPostProcessUniforms.bloomRadius) globalPostProcessUniforms.bloomRadius.value = s.bloom.radius;
+        if (globalPostProcessUniforms.bloomThreshold) globalPostProcessUniforms.bloomThreshold.value = s.bloom.threshold;
+        postProcessVolumeManager?.setDefaultSettings?.({
+            bloomStrength: s.bloom.strength,
+            bloomRadius: s.bloom.radius,
+            bloomThreshold: s.bloom.threshold,
+        });
+    } else {
+        postProcessVolumeManager?.setEnabled?.(false);
+    }
+
+    // Fog
+    if (getVolumetricFogController()) {
+        getVolumetricFogController().setEnabled?.(s.fog.enabled);
+        getVolumetricFogController().setDensity?.(s.fog.density);
+        getVolumetricFogController().setOpacity?.(s.fog.opacity);
+    }
+
+    // DDGI
+    const ddgi = getDDGIManager();
+    ddgi?.setEnabled?.(s.ddgi.enabled);
+    ddgi?.setInjectionEnabled?.(s.ddgi.enabled);
+    ddgi?.setProbesPerFrame?.(s.ddgi.probesPerFrame);
+    ddgi?.setIntensity?.(s.ddgi.intensity);
+
+    // Shadows
+    if (renderer?.shadowMap) {
+        renderer.shadowMap.enabled = s.shadows.enabled;
+    }
+
+    if (persist) saveWorldEnvToStorage();
+    updateWorldEnvUi();
+}
+
+export function updateWorldEnvUi() {
+    if (!worldEnvUiRefs) return;
+    const s = worldEnvState;
+    const setToggle = (offBtn, onBtn, on) => {
+        offBtn?.classList.toggle('viewer-toggle-btn-active', !on);
+        onBtn?.classList.toggle('viewer-toggle-btn-active', on);
+    };
+    const setSlider = (input, valueEl, value, decimals) => {
+        if (input) input.value = value;
+        if (valueEl) valueEl.textContent = Number(value).toFixed(decimals);
+    };
+
+    setToggle(worldEnvUiRefs.skyOff, worldEnvUiRefs.skyOn, s.sky.enabled);
+    if (worldEnvUiRefs.skyPreset) worldEnvUiRefs.skyPreset.value = s.sky.preset;
+    setSlider(worldEnvUiRefs.skyBlurriness, worldEnvUiRefs.skyBlurrinessValue, s.sky.blurriness, 2);
+
+    setToggle(worldEnvUiRefs.ambientOff, worldEnvUiRefs.ambientOn, s.ambient.enabled);
+    setSlider(worldEnvUiRefs.ambientIntensity, worldEnvUiRefs.ambientIntensityValue, s.ambient.intensity, 2);
+
+    setToggle(worldEnvUiRefs.hemiOff, worldEnvUiRefs.hemiOn, s.hemi.enabled);
+    setSlider(worldEnvUiRefs.hemiIntensity, worldEnvUiRefs.hemiIntensityValue, s.hemi.intensity, 2);
+
+    setToggle(worldEnvUiRefs.sunOff, worldEnvUiRefs.sunOn, s.sun.enabled);
+    if (worldEnvUiRefs.sunShadow) worldEnvUiRefs.sunShadow.checked = s.sun.castShadow;
+    setSlider(worldEnvUiRefs.sunIntensity, worldEnvUiRefs.sunIntensityValue, s.sun.intensity, 2);
+
+    setSlider(worldEnvUiRefs.exposure, worldEnvUiRefs.exposureValue, s.tonemap.exposure, 2);
+
+    setToggle(worldEnvUiRefs.bloomOff, worldEnvUiRefs.bloomOn, s.bloom.enabled);
+    setSlider(worldEnvUiRefs.bloomStrength, worldEnvUiRefs.bloomStrengthValue, s.bloom.strength, 2);
+    setSlider(worldEnvUiRefs.bloomRadius, worldEnvUiRefs.bloomRadiusValue, s.bloom.radius, 2);
+    setSlider(worldEnvUiRefs.bloomThreshold, worldEnvUiRefs.bloomThresholdValue, s.bloom.threshold, 2);
+
+    setToggle(worldEnvUiRefs.fogOff, worldEnvUiRefs.fogOn, s.fog.enabled);
+    setSlider(worldEnvUiRefs.fogDensity, worldEnvUiRefs.fogDensityValue, s.fog.density, 3);
+    setSlider(worldEnvUiRefs.fogOpacity, worldEnvUiRefs.fogOpacityValue, s.fog.opacity, 3);
+
+    setToggle(worldEnvUiRefs.ddgiOff, worldEnvUiRefs.ddgiOn, s.ddgi.enabled);
+    if (worldEnvUiRefs.ddgiProbes) worldEnvUiRefs.ddgiProbes.value = s.ddgi.probesPerFrame;
+    if (worldEnvUiRefs.ddgiProbesValue) worldEnvUiRefs.ddgiProbesValue.textContent = String(s.ddgi.probesPerFrame);
+    setSlider(worldEnvUiRefs.ddgiIntensity, worldEnvUiRefs.ddgiIntensityValue, s.ddgi.intensity, 2);
+
+    setToggle(worldEnvUiRefs.shadowsOff, worldEnvUiRefs.shadowsOn, s.shadows.enabled);
+
+    // Summary chip + status text
+    if (worldEnvUiRefs.summaryValue) {
+        const off = [];
+        if (!s.sky.enabled) off.push('Sky');
+        if (!s.bloom.enabled) off.push('Bloom');
+        if (!s.fog.enabled) off.push('Fog');
+        if (!s.ddgi.enabled) off.push('DDGI');
+        if (!s.shadows.enabled) off.push('Shadows');
+        worldEnvUiRefs.summaryValue.textContent = off.length ? `Off: ${off.join(' · ')}` : 'All effects active';
+    }
+    if (worldEnvUiRefs.masterStatus) {
+        const allCoreOn = s.sky.enabled && s.ambient.enabled && s.hemi.enabled && s.sun.enabled && s.bloom.enabled && s.fog.enabled && s.shadows.enabled;
+        const perfPreset = !s.bloom.enabled && !s.fog.enabled && !s.ddgi.enabled && s.sky.enabled && s.sun.enabled;
+        if (allCoreOn && !s.ddgi.enabled) {
+            worldEnvUiRefs.masterStatus.textContent = 'Everything on (DDGI off — opt in for prettier indirect lighting).';
+        } else if (allCoreOn && s.ddgi.enabled) {
+            worldEnvUiRefs.masterStatus.textContent = 'Everything on, including DDGI.';
+        } else if (perfPreset) {
+            worldEnvUiRefs.masterStatus.textContent = 'Performance preset active. Bloom + Fog + DDGI paused.';
+        } else {
+            worldEnvUiRefs.masterStatus.textContent = 'Custom configuration.';
+        }
+    }
+}
+
+export function setWorldEnvMaster(mode) {
+    const s = worldEnvState;
+    if (mode === 'on') {
+        s.sky.enabled = true;
+        s.ambient.enabled = true;
+        s.hemi.enabled = true;
+        s.sun.enabled = true;
+        s.bloom.enabled = true;
+        s.fog.enabled = true;
+        s.shadows.enabled = true;
+        // DDGI is opt-in even with All On — too expensive for a default.
+    } else if (mode === 'off') {
+        s.sky.enabled = false;
+        s.ambient.enabled = false;
+        s.hemi.enabled = false;
+        s.sun.enabled = false;
+        s.bloom.enabled = false;
+        s.fog.enabled = false;
+        s.ddgi.enabled = false;
+        s.shadows.enabled = false;
+    } else if (mode === 'perf') {
+        // Performance preset: only the heavy effects go off.
+        s.bloom.enabled = false;
+        s.fog.enabled = false;
+        s.ddgi.enabled = false;
+    }
+    applyWorldEnvState();
+}
+
+export function resetWorldEnvDefaults() {
+    worldEnvState = JSON.parse(JSON.stringify(WORLD_ENV_DEFAULTS));
+    applyWorldEnvState();
+}
+
+export function createSceneActorItem(actor, { isChild = false } = {}) {
+    const item = document.createElement('div');
+    item.className = isChild ? 'scene-ui-item scene-ui-child-item' : 'scene-ui-item';
+    item.dataset.id = actor.id;
+
+    if (objectScriptState.targetPropId === actor.id) {
+        item.style.background = 'rgba(255, 255, 255, 0.12)';
+        item.style.borderColor = 'rgba(112, 0, 255, 0.45)';
+        if (!blueprintState.active) {
+            const actorBtnRow = document.createElement('div');
+            actorBtnRow.className = 'scene-ui-item-actions';
+
+            const blueprintBtn = document.createElement('button');
+            blueprintBtn.className = 'btn btn-primary scene-ui-action-btn';
+            blueprintBtn.textContent = 'Edit Blueprint';
+            blueprintBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                enterBlueprintEditor();
+                syncBlueprintPhysicsEditor(actor);
+            });
+            actorBtnRow.appendChild(blueprintBtn);
+
+            const saveActorBtn = document.createElement('button');
+            saveActorBtn.className = 'btn scene-ui-action-btn scene-ui-save-btn';
+            saveActorBtn.textContent = 'Save';
+            saveActorBtn.title = 'Download this actor as a .actor file';
+            saveActorBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                exportActorToFile(actor);
+            });
+            actorBtnRow.appendChild(saveActorBtn);
+            item.appendChild(actorBtnRow);
+        }
+    }
+
+    const nameEl = document.createElement('div');
+    nameEl.className = 'scene-ui-item-name';
+    nameEl.textContent = actor.rootNode.name || actor.id || 'Actor';
+
+    const typeEl = document.createElement('div');
+    typeEl.className = 'scene-ui-item-type';
+    typeEl.textContent = actorInheritsCore(actor) ? 'instance' : (actor.kind || 'Actor');
+
+    item.appendChild(nameEl);
+    item.appendChild(typeEl);
+    item.addEventListener('click', () => selectShowcaseActor(actor.id));
+    item.addEventListener('dblclick', () => focusSceneActor(actor));
+    return item;
+}
+
+export function refreshSceneUI() {
+    if (collisionDebugState.enabled) {
+        refreshCollisionDebugOverlays();
+    }
+
+    if (!sceneUiList || !sceneUiCount) return;
+
+    sceneUiList.innerHTML = '';
+
+    if (!sceneSystem || sceneSystem.actors.size === 0) {
+        sceneUiCount.textContent = '0 Actors';
+        return;
+    }
+
+    const actors = Array.from(sceneSystem.actors);
+    sceneUiCount.textContent = `${actors.length} Actor${actors.length !== 1 ? 's' : ''}`;
+
+    actors.forEach((actor) => sceneUiList.appendChild(createSceneActorItem(actor)));
+
+    const cores = actors.filter((actor) => !actorInheritsCore(actor)
+        && actors.some((entry) => actorInheritsCore(entry) && getActorCoreSource(entry)?.id === actor.id));
+    if (cores.length) {
+        const folder = document.createElement('div');
+        folder.className = 'scene-ui-folder scene-ui-core-bin';
+        if (refreshSceneUI.coreBinCollapsed) {
+            folder.classList.add('scene-ui-folder-collapsed');
+        }
+
+        const header = document.createElement('button');
+        header.className = 'scene-ui-folder-header';
+        header.type = 'button';
+        header.textContent = 'Core Actors';
+
+        const count = document.createElement('span');
+        count.textContent = `${cores.length} parent${cores.length !== 1 ? 's' : ''}`;
+        header.appendChild(count);
+        header.addEventListener('click', () => {
+            refreshSceneUI.coreBinCollapsed = !refreshSceneUI.coreBinCollapsed;
+            refreshSceneUI();
+        });
+        folder.appendChild(header);
+
+        if (!refreshSceneUI.coreBinCollapsed) {
+            cores.forEach((actor) => {
+                const linked = actors.filter((entry) => actorInheritsCore(entry) && getActorCoreSource(entry)?.id === actor.id);
+                const row = createSceneActorItem(actor);
+                const type = row.querySelector('.scene-ui-item-type');
+                if (type) type.textContent = `parent core · ${linked.length} linked`;
+                folder.appendChild(row);
+            });
+        }
+
+        sceneUiList.appendChild(folder);
+    }
+    return;
+
+    actors.forEach(actor => {
+        const item = document.createElement('div');
+        item.className = 'scene-ui-item';
+        item.dataset.id = actor.id;
+
+        if (objectScriptState.targetPropId === actor.id) {
+            item.style.background = 'rgba(255, 255, 255, 0.12)';
+            item.style.borderColor = 'rgba(112, 0, 255, 0.45)';
+            
+            if (!blueprintState.active) {
+                const actorBtnRow = document.createElement('div');
+                actorBtnRow.className = 'scene-ui-item-actions';
+
+                const blueprintBtn = document.createElement('button');
+                blueprintBtn.className = 'btn btn-primary scene-ui-action-btn';
+                blueprintBtn.textContent = 'Edit Blueprint';
+                blueprintBtn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    enterBlueprintEditor();
+                    syncBlueprintPhysicsEditor(actor);
+                });
+                actorBtnRow.appendChild(blueprintBtn);
+
+                const saveActorBtn = document.createElement('button');
+                saveActorBtn.className = 'btn scene-ui-action-btn scene-ui-save-btn';
+                saveActorBtn.textContent = '⬇ Save';
+                saveActorBtn.title = 'Download this actor as a .actor file';
+                saveActorBtn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    exportActorToFile(actor);
+                });
+                actorBtnRow.appendChild(saveActorBtn);
+
+                item.appendChild(actorBtnRow);
+            }
+        }
+
+        const nameEl = document.createElement('div');
+        nameEl.className = 'scene-ui-item-name';
+        nameEl.textContent = actor.rootNode.name || actor.id || 'Actor';
+
+        const typeEl = document.createElement('div');
+        typeEl.className = 'scene-ui-item-type';
+        typeEl.textContent = actor.kind || 'Actor';
+
+        item.appendChild(nameEl);
+        item.appendChild(typeEl);
+
+        item.addEventListener('click', () => {
+            selectShowcaseActor(actor.id);
+        });
+
+        item.addEventListener('dblclick', () => {
+            const actorMesh = getActorRenderObject(actor);
+            if (!gameplay.active && actorMesh) {
+                const targetPos = new THREE.Vector3();
+                actorMesh.getWorldPosition(targetPos);
+                
+                if (gsap) {
+                    gsap.to(camera.position, {
+                        x: targetPos.x + 2.5,
+                        y: targetPos.y + 2.5,
+                        z: targetPos.z + 2.5,
+                        duration: 0.6,
+                        ease: 'power2.out',
+                        onUpdate: () => {
+                            syncShowcaseAnglesFromTarget(targetPos);
+                            applyShowcaseCameraRotation();
+                        }
+                    });
+                } else {
+                    camera.position.set(targetPos.x + 2.5, targetPos.y + 2.5, targetPos.z + 2.5);
+                    syncShowcaseAnglesFromTarget(targetPos);
+                    applyShowcaseCameraRotation();
+                }
+            }
+        });
+
+        sceneUiList.appendChild(item);
+    });
+}

--- a/src/editor/terrainPanel.js
+++ b/src/editor/terrainPanel.js
@@ -1,0 +1,336 @@
+// src/editor/terrainPanel.js
+// Extracted from main.js (chore/main-js-shrink-2). Owns the terrain editor's
+// brush helper, paint-from-event handlers, the terrain DOM panel wiring
+// (`setupTerrainPanel()`), and the serialize/apply terrain-state hooks.
+//
+// `worldFloor` and `grassField` are assigned in init() AFTER wireExtractedModules
+// runs, so they come through here as getter callbacks.
+
+import * as THREE from 'three';
+
+let terrainBrushState, gameplay, blueprintState;
+let camera, renderer, pointerNdc, raycaster;
+let getWorldFloor, getGrassField;
+let applySerializedTerrainState, serializeTerrainState;
+let rebuildTerrainPhysicsBody;
+let applyTerrainSculptBrush;
+let setTerrainCustomImage, setTerrainModeGrassPBR, setTerrainModeGrid, setTerrainModeSolid;
+let setTerrainRepeat, setTerrainRoughness, setTerrainTint;
+let ensurePlayerCharacter, updateWorldPresentation, updateGameplayUI;
+
+export function installTerrainPanel(deps) {
+    ({
+        terrainBrushState, gameplay, blueprintState,
+        camera, renderer, pointerNdc, raycaster,
+        getWorldFloor, getGrassField,
+        applySerializedTerrainState, serializeTerrainState,
+        rebuildTerrainPhysicsBody,
+        applyTerrainSculptBrush,
+        setTerrainCustomImage, setTerrainModeGrassPBR, setTerrainModeGrid, setTerrainModeSolid,
+        setTerrainRepeat, setTerrainRoughness, setTerrainTint,
+        ensurePlayerCharacter, updateWorldPresentation, updateGameplayUI,
+    } = deps);
+}
+
+export function ensureTerrainBrushHelper() {
+    if (terrainBrushState.helper) return terrainBrushState.helper;
+    const geometry = new THREE.RingGeometry(0.96, 1, 96);
+    const material = new THREE.MeshBasicMaterial({
+        color: 0x00ffaa,
+        transparent: true,
+        opacity: 0.85,
+        depthTest: false,
+        depthWrite: false,
+        side: THREE.DoubleSide,
+    });
+    const helper = new THREE.Mesh(geometry, material);
+    helper.name = 'TerrainBrushPreview';
+    helper.renderOrder = 999;
+    helper.visible = false;
+    terrainBrushState.helper = helper;
+    getWorldFloor()?.add(helper);
+    return helper;
+}
+
+export function getTerrainHitFromEvent(event) {
+    if (!renderer || !getWorldFloor()) return null;
+    const rect = renderer.domElement.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return null;
+    pointerNdc.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    pointerNdc.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    raycaster.setFromCamera(pointerNdc, camera);
+    const hit = raycaster.intersectObject(getWorldFloor(), false)[0];
+    if (!hit) return null;
+    const local = getWorldFloor().worldToLocal(hit.point.clone());
+    return { hit, local };
+}
+
+export function updateTerrainBrushPreview(event) {
+    const helper = ensureTerrainBrushHelper();
+    if (!terrainBrushState.enabled || gameplay.active || blueprintState.active) {
+        helper.visible = false;
+        return null;
+    }
+    const terrainHit = getTerrainHitFromEvent(event);
+    if (!terrainHit) {
+        helper.visible = false;
+        return null;
+    }
+    helper.visible = true;
+    helper.position.set(terrainHit.local.x, terrainHit.local.y, terrainHit.local.z + 0.035);
+    helper.scale.setScalar(terrainBrushState.radius);
+    const foliagePreviewColor = terrainBrushState.foliageType === 'tree'
+        ? 0x2f7d32
+        : terrainBrushState.foliageType === 'bush'
+            ? 0x55a545
+            : 0xa8d96b;
+    helper.material.color.set(terrainBrushState.tool.includes('foliage') ? foliagePreviewColor : terrainBrushState.tool === 'paint' ? terrainBrushState.paintColor : 0x00ffaa);
+    return terrainHit;
+}
+
+export function applyTerrainBrushFromEvent(event) {
+    const terrainHit = updateTerrainBrushPreview(event);
+    if (!terrainHit) return false;
+
+    const { local } = terrainHit;
+    const tool = terrainBrushState.tool;
+    if (tool === 'foliage' || tool === 'erase-foliage') {
+        getGrassField()?.paintFoliage?.({
+            terrain: getWorldFloor(),
+            localX: local.x,
+            localY: local.y,
+            radius: terrainBrushState.radius,
+            density: terrainBrushState.foliageDensity,
+            mode: event.shiftKey || tool === 'erase-foliage' ? 'erase' : 'add',
+            type: terrainBrushState.foliageType,
+        });
+        return true;
+    }
+
+    const changed = applyTerrainSculptBrush(getWorldFloor(), {
+        localX: local.x,
+        localY: local.y,
+        radius: terrainBrushState.radius,
+        strength: terrainBrushState.strength,
+        mode: tool,
+        targetHeight: terrainBrushState.flattenHeight,
+        paintColor: terrainBrushState.paintColor,
+        invert: event.shiftKey,
+    });
+    if (changed) {
+        getGrassField()?.syncToTerrain?.(getWorldFloor(), {
+            localX: local.x,
+            localY: local.y,
+            radius: terrainBrushState.radius + 2,
+        });
+        terrainBrushState.dirtyPhysics = true;
+    }
+    return changed;
+}
+
+export function serializeWorldTerrainState() {
+    return {
+        terrain: serializeTerrainState(getWorldFloor()),
+        foliage: getGrassField()?.serializeFoliage?.() ?? null,
+    };
+}
+
+export function applyWorldTerrainState(data = {}) {
+    applySerializedTerrainState(getWorldFloor(), data.terrain);
+    rebuildTerrainPhysicsBody();
+    getGrassField()?.applySerializedFoliage?.(data.foliage ?? {}, getWorldFloor());
+    getGrassField()?.syncToTerrain?.(getWorldFloor());
+    if (physics.ready) {
+        ensurePlayerCharacter();
+        gameplay.canPlay = true;
+        updateWorldPresentation();
+        updateGameplayUI();
+    }
+}
+
+export function setupTerrainPanel() {
+    const modeSel = document.getElementById('terrain-mode');
+    const colorIn = document.getElementById('terrain-color');
+    const repeatIn = document.getElementById('terrain-repeat');
+    const repeatVal = document.getElementById('terrain-repeat-value');
+    const roughIn = document.getElementById('terrain-roughness');
+    const roughVal = document.getElementById('terrain-roughness-value');
+    const summary = document.getElementById('terrain-summary-value');
+    const loadBtn = document.getElementById('terrain-load-image');
+    const loadInput = document.getElementById('terrain-image-input');
+    const sculptOff = document.getElementById('terrain-sculpt-off');
+    const sculptOn = document.getElementById('terrain-sculpt-on');
+    const sculptTool = document.getElementById('terrain-sculpt-tool');
+    const sculptRadius = document.getElementById('terrain-sculpt-radius');
+    const sculptRadiusVal = document.getElementById('terrain-sculpt-radius-value');
+    const sculptStrength = document.getElementById('terrain-sculpt-strength');
+    const sculptStrengthVal = document.getElementById('terrain-sculpt-strength-value');
+    const sculptFlatten = document.getElementById('terrain-flatten-height');
+    const sculptFlattenVal = document.getElementById('terrain-flatten-height-value');
+    const sculptPaintColor = document.getElementById('terrain-paint-color');
+    const foliageType = document.getElementById('terrain-foliage-type');
+    const foliageDensity = document.getElementById('terrain-foliage-density');
+    const foliageDensityVal = document.getElementById('terrain-foliage-density-value');
+
+    const grassOff = document.getElementById('grass-off');
+    const grassOn = document.getElementById('grass-on');
+    const grassBase = document.getElementById('grass-base-color');
+    const grassTip = document.getElementById('grass-tip-color');
+    const grassWind = document.getElementById('grass-wind');
+    const grassWindVal = document.getElementById('grass-wind-value');
+
+    const updateSummary = () => {
+        if (!summary) return;
+        const mode = modeSel?.value ?? 'grid';
+        summary.textContent = `${mode} · ${terrainBrushState.enabled ? 'sculpt' : colorIn?.value ?? '#fff'}`;
+    };
+
+    modeSel?.addEventListener('change', async () => {
+        const mode = modeSel.value;
+        if (mode === 'grid') await setTerrainModeGrid(getWorldFloor());
+        else if (mode === 'solid') setTerrainModeSolid(getWorldFloor());
+        else if (mode === 'grass') await setTerrainModeGrassPBR(getWorldFloor());
+        else if (mode === 'custom') loadInput?.click();
+        setTerrainRepeat(getWorldFloor(), parseFloat(repeatIn?.value ?? 28));
+        updateSummary();
+    });
+
+    colorIn?.addEventListener('input', () => {
+        setTerrainTint(getWorldFloor(), colorIn.value);
+        updateSummary();
+    });
+
+    repeatIn?.addEventListener('input', () => {
+        const v = parseFloat(repeatIn.value);
+        if (repeatVal) repeatVal.textContent = String(v);
+        setTerrainRepeat(getWorldFloor(), v);
+    });
+
+    roughIn?.addEventListener('input', () => {
+        const v = parseFloat(roughIn.value);
+        if (roughVal) roughVal.textContent = v.toFixed(2);
+        setTerrainRoughness(getWorldFloor(), v);
+    });
+
+    loadBtn?.addEventListener('click', () => loadInput?.click());
+    loadInput?.addEventListener('change', () => {
+        const file = loadInput.files?.[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+            setTerrainCustomImage(getWorldFloor(), reader.result);
+            if (modeSel) modeSel.value = 'custom';
+            updateSummary();
+        };
+        reader.readAsDataURL(file);
+    });
+
+    const setSculptEnabled = (enabled) => {
+        terrainBrushState.enabled = enabled;
+        terrainBrushState.active = false;
+        sculptOn?.classList.toggle('viewer-toggle-btn-active', enabled);
+        sculptOff?.classList.toggle('viewer-toggle-btn-active', !enabled);
+        if (!enabled && terrainBrushState.helper) terrainBrushState.helper.visible = false;
+        updateSummary();
+    };
+    sculptOn?.addEventListener('click', () => setSculptEnabled(true));
+    sculptOff?.addEventListener('click', () => setSculptEnabled(false));
+
+    sculptTool?.addEventListener('change', () => {
+        terrainBrushState.tool = sculptTool.value;
+    });
+    sculptRadius?.addEventListener('input', () => {
+        const v = parseFloat(sculptRadius.value);
+        terrainBrushState.radius = v;
+        if (sculptRadiusVal) sculptRadiusVal.textContent = v.toFixed(1);
+    });
+    sculptStrength?.addEventListener('input', () => {
+        const v = parseFloat(sculptStrength.value);
+        terrainBrushState.strength = v;
+        if (sculptStrengthVal) sculptStrengthVal.textContent = v.toFixed(2);
+    });
+    sculptFlatten?.addEventListener('input', () => {
+        const v = parseFloat(sculptFlatten.value);
+        terrainBrushState.flattenHeight = v;
+        if (sculptFlattenVal) sculptFlattenVal.textContent = v.toFixed(1);
+    });
+    sculptPaintColor?.addEventListener('input', () => {
+        terrainBrushState.paintColor = sculptPaintColor.value;
+    });
+    foliageType?.addEventListener('change', () => {
+        terrainBrushState.foliageType = foliageType.value;
+    });
+    foliageDensity?.addEventListener('input', () => {
+        const v = parseInt(foliageDensity.value, 10);
+        terrainBrushState.foliageDensity = v;
+        if (foliageDensityVal) foliageDensityVal.textContent = String(v);
+    });
+
+    const setGrassEnabled = (enabled) => {
+        if (getGrassField()?.setVisible) getGrassField().setVisible(enabled);
+        else if (getGrassField()?.mesh) getGrassField().mesh.visible = enabled;
+        grassOn?.classList.toggle('viewer-toggle-btn-active', enabled);
+        grassOff?.classList.toggle('viewer-toggle-btn-active', !enabled);
+    };
+    grassOn?.addEventListener('click', () => setGrassEnabled(true));
+    grassOff?.addEventListener('click', () => setGrassEnabled(false));
+
+    const applyGrassColors = () => {
+        if (!getGrassField()) return;
+        const base = new THREE.Color(grassBase?.value ?? '#2f5a1c');
+        const tip = new THREE.Color(grassTip?.value ?? '#a8d96b');
+        getGrassField().setColors?.(base, tip);
+    };
+    grassBase?.addEventListener('input', applyGrassColors);
+    grassTip?.addEventListener('input', applyGrassColors);
+
+    grassWind?.addEventListener('input', () => {
+        const v = parseFloat(grassWind.value);
+        if (grassWindVal) grassWindVal.textContent = v.toFixed(2);
+        getGrassField()?.setWind?.(1, 0.3, v);
+    });
+
+    const spriteLoadBtn = document.getElementById('grass-sprite-load');
+    const spriteClearBtn = document.getElementById('grass-sprite-clear');
+    const spriteInput = document.getElementById('grass-sprite-input');
+    const spriteStatus = document.getElementById('grass-sprite-status');
+    const spriteTintIn = document.getElementById('grass-sprite-tint');
+    const spriteTintVal = document.getElementById('grass-sprite-tint-value');
+    const alphaCutoffIn = document.getElementById('grass-alpha-cutoff');
+    const alphaCutoffVal = document.getElementById('grass-alpha-cutoff-value');
+
+    spriteLoadBtn?.addEventListener('click', () => spriteInput?.click());
+    spriteInput?.addEventListener('change', () => {
+        const file = spriteInput.files?.[0];
+        if (!file || !getGrassField()) return;
+        const reader = new FileReader();
+        reader.onload = async () => {
+            try {
+                await getGrassField().setSpriteFromUrl?.(reader.result);
+                if (spriteStatus) spriteStatus.textContent = `Loaded: ${file.name}`;
+            } catch (err) {
+                console.error('Grass sprite load failed', err);
+                if (spriteStatus) spriteStatus.textContent = `Failed to load ${file.name}`;
+            }
+        };
+        reader.readAsDataURL(file);
+    });
+    spriteClearBtn?.addEventListener('click', () => {
+        getGrassField()?.clearSprite?.();
+        if (spriteStatus) spriteStatus.textContent = 'Sprite cleared — using procedural blades.';
+    });
+
+    spriteTintIn?.addEventListener('input', () => {
+        const v = parseFloat(spriteTintIn.value);
+        if (spriteTintVal) spriteTintVal.textContent = v.toFixed(2);
+        getGrassField()?.setSpriteTint?.(v);
+    });
+
+    alphaCutoffIn?.addEventListener('input', () => {
+        const v = parseFloat(alphaCutoffIn.value);
+        if (alphaCutoffVal) alphaCutoffVal.textContent = v.toFixed(2);
+        getGrassField()?.setAlphaTest?.(v);
+    });
+
+    updateSummary();
+}

--- a/src/gameplay/gameplayLoop.js
+++ b/src/gameplay/gameplayLoop.js
@@ -1,0 +1,1124 @@
+// src/gameplay/gameplayLoop.js
+// Extracted from main.js (chore/main-js-shrink-2). Holds the play-mode loop,
+// the showcase free-fly camera, the gameplay/showcase keyboard+mouse handlers,
+// the gameplay UI sync, and the small spawn / camera helpers that pair with them.
+//
+// External flow surfaces that stay in main.js (called from here via deps):
+//   - vehicle: imported from ../vehicle/vehicleController.js (isDrivingVehicle, ...)
+//   - mouse actions / object script editor: src/scripting/* (already extracted)
+//   - debug console / mobile / blueprint: src/debug + src/ui + src/editor (extracted)
+//   - physics: rebuildTerrainPhysicsBody / rebuildModelPhysicsBody / ensurePlayerCharacter
+//     / syncCameraToCharacter / spawnDrivableCar still live in main.js — passed as deps.
+
+import * as THREE from 'three';
+import gsap from 'gsap';
+import {
+    isDrivingVehicle, exitVehicle, enterVehicle, clearActiveVehicle,
+    updateVehicleGameplay,
+} from '../vehicle/vehicleController.js';
+import {
+    silenceVehicleEngineAudio, updateEngineAudioDebugOverlay, playAudioTestCue,
+} from '../audio/vehicleEngineAudio.js';
+
+// Module-scope deps — populated by setupGameplayLoop. Late-init refs (worldFloor,
+// mainDirectionalLight, currentMesh, pedestal, resetViewBtn, gameplayStatus, playHint)
+// are exposed via getters because they are assigned AFTER wireExtractedModules
+// runs (in init() at main.js around L5158).
+let THREE_ /* unused, kept for parity */;
+let gameplay, physics, showcase, vehicleState, blueprintState, mobileState;
+let terrainBrushState, debugConsoleState, collisionDebugState, importedPropState, objectScriptState;
+let camera, renderer, container;
+let pointerNdc, raycaster, editorHistory, transformControl;
+let gameplayLookTarget, gameplayBounds, mainDirectionalLightShadowFocus, mainDirectionalLightOffset;
+let upVector, tempVectorA, tempVectorB, tempVectorC, tempVectorD, tempVectorE;
+let PLAYER_SETTINGS, VEHICLE_SETTINGS, TERRAIN_Y_OFFSET;
+let SHOWCASE_CAMERA_POSITION, SHOWCASE_CAMERA_TARGET;
+let runtimeAudio;
+let getCurrentMesh, getWorldFloor, getMainDirectionalLight, getPedestal;
+let getResetViewBtn, getGameplayStatus, getPlayHint, getSceneUiList;
+let setCollisionDebugEnabled;
+let isEditableElement;
+let runMouseAction, applyMouseActionScripts;
+let handleDebugConsoleKeydown;
+let closeObjectScriptMenu, closeObjectScriptEditor, maybeOpenObjectScriptMenuFromMobileTap;
+let isTransformControlSphereHit, handleLightGridClick, focusShowcaseCameraOnObject;
+let selectShowcaseActor, syncTransformControlState;
+let snapshotSceneState, restoreSceneState;
+let updateMouseActionStatus, updateMobileButtons;
+let updateCameraModeButtons, updateBlueprintTransformUI, refreshBlueprintComponents;
+let onWindowResize;
+let getDynamicPropHitFromEvent, getDynamicPropById, getActorRenderObject;
+let applyTerrainBrushFromEvent, updateTerrainBrushPreview;
+let rebuildTerrainPhysicsBody, rebuildModelPhysicsBody, ensurePlayerCharacter, syncCameraToCharacter;
+let copyJoltVector, updateRaycasterDebugLine, positionLightGrid;
+let getGroundHitAt, getGroundHeightAt;
+let spawnDrivableCar;
+let resetAllScriptLifecycleHandles;
+let copySelectedToClipboard, pasteFromClipboard, deleteSelectedActor, duplicateSelected;
+
+export function setupGameplayLoop(deps) {
+    ({
+        gameplay, physics, showcase, vehicleState, blueprintState, mobileState,
+        terrainBrushState, debugConsoleState, collisionDebugState, importedPropState, objectScriptState,
+        camera, renderer, container,
+        pointerNdc, raycaster, editorHistory, transformControl,
+        gameplayLookTarget, gameplayBounds, mainDirectionalLightShadowFocus, mainDirectionalLightOffset,
+        upVector, tempVectorA, tempVectorB, tempVectorC, tempVectorD, tempVectorE,
+        PLAYER_SETTINGS, VEHICLE_SETTINGS, TERRAIN_Y_OFFSET,
+        SHOWCASE_CAMERA_POSITION, SHOWCASE_CAMERA_TARGET,
+        runtimeAudio,
+        getCurrentMesh, getWorldFloor, getMainDirectionalLight, getPedestal,
+        getResetViewBtn, getGameplayStatus, getPlayHint, getSceneUiList,
+        setCollisionDebugEnabled,
+        isEditableElement,
+        runMouseAction, applyMouseActionScripts,
+        handleDebugConsoleKeydown,
+        closeObjectScriptMenu, closeObjectScriptEditor, maybeOpenObjectScriptMenuFromMobileTap,
+        isTransformControlSphereHit, handleLightGridClick, focusShowcaseCameraOnObject,
+        selectShowcaseActor, syncTransformControlState,
+        snapshotSceneState, restoreSceneState,
+        updateMouseActionStatus, updateMobileButtons,
+        updateCameraModeButtons, updateBlueprintTransformUI, refreshBlueprintComponents,
+        onWindowResize,
+        getDynamicPropHitFromEvent, getDynamicPropById, getActorRenderObject,
+        applyTerrainBrushFromEvent, updateTerrainBrushPreview,
+        rebuildTerrainPhysicsBody, rebuildModelPhysicsBody, ensurePlayerCharacter, syncCameraToCharacter,
+        copyJoltVector, updateRaycasterDebugLine, positionLightGrid,
+        getGroundHitAt, getGroundHeightAt,
+        spawnDrivableCar,
+        resetAllScriptLifecycleHandles,
+        copySelectedToClipboard, pasteFromClipboard, deleteSelectedActor, duplicateSelected,
+    } = deps);
+}
+
+export function resetMobileInputState() {
+    resetMovementInputState();
+    resetMobileMovePad();
+    resetMobileLookPad();
+}
+
+export function resetMovementInputState() {
+    showcase.input.forward = false;
+    showcase.input.back = false;
+    showcase.input.left = false;
+    showcase.input.right = false;
+    showcase.input.up = false;
+    showcase.input.down = false;
+    showcase.input.boost = false;
+    gameplay.input.forward = false;
+    gameplay.input.back = false;
+    gameplay.input.left = false;
+    gameplay.input.right = false;
+    gameplay.input.sprint = false;
+    physics.jumpQueued = false;
+}
+
+export function refreshGameplayWorld() {
+    if (!getCurrentMesh()) {
+        gameplay.canPlay = physics.ready;
+        updateGameplayUI();
+        return;
+    }
+
+    getCurrentMesh().updateWorldMatrix(true, true);
+    gameplayBounds.setFromObject(getCurrentMesh());
+    gameplayLookTarget.copy(gameplayBounds.getCenter(tempVectorA));
+
+    const worldSize = gameplayBounds.getSize(tempVectorB);
+    const floorScale = Math.max(1, worldSize.x / 18, worldSize.z / 18);
+    getWorldFloor().scale.setScalar(floorScale);
+    getWorldFloor().position.set(gameplayLookTarget.x, TERRAIN_Y_OFFSET, gameplayLookTarget.z);
+    positionLightGrid(gameplayLookTarget);
+
+    const topHit = getGroundHitAt(gameplayLookTarget.x, gameplayLookTarget.z, false);
+    if (topHit && topHit.point.y > getWorldFloor().position.y + 0.15) {
+        gameplay.spawnPoint.set(
+            gameplayLookTarget.x,
+            topHit.point.y + PLAYER_SETTINGS.floorOffset,
+            gameplayLookTarget.z
+        );
+    } else {
+        const fallbackZ = gameplayBounds.max.z + Math.max(worldSize.z * 0.25, 2.5);
+        const fallbackY = getGroundHeightAt(gameplayLookTarget.x, fallbackZ, true) ?? getWorldFloor().position.y;
+        gameplay.spawnPoint.set(
+            gameplayLookTarget.x,
+            fallbackY + PLAYER_SETTINGS.floorOffset,
+            fallbackZ
+        );
+    }
+
+    gameplay.velocity.set(0, 0, 0);
+    gameplay.grounded = false;
+    rebuildTerrainPhysicsBody();
+    rebuildModelPhysicsBody();
+    if (physics.ready) {
+        ensurePlayerCharacter();
+    }
+    gameplay.canPlay = !!physics.character;
+    updateWorldPresentation();
+    resetShowcaseCamera(false);
+    updateGameplayUI();
+}
+
+export function setupGameplayEvents() {
+    const resumeAudio = () => {
+        runtimeAudio.resume();
+    };
+
+    document.addEventListener('pointerdown', resumeAudio, { passive: true });
+    document.addEventListener('touchend', resumeAudio, { passive: true });
+    document.addEventListener('keydown', resumeAudio);
+    document.addEventListener('pointerlockchange', handlePointerLockChange);
+    document.addEventListener('mousemove', handleGameplayMouseMove);
+    document.addEventListener('keydown', handleDebugConsoleKeydown, true);
+    document.addEventListener('keydown', handleGameplayKeyEvent);
+    document.addEventListener('keyup', handleGameplayKeyEvent);
+    renderer.domElement.addEventListener('mousedown', handleShowcaseMouseButton);
+    window.addEventListener('mouseup', handleShowcaseMouseButton);
+    renderer.domElement.addEventListener('wheel', handleShowcaseWheel, { passive: false });
+    renderer.domElement.addEventListener('contextmenu', handleShowcaseContextMenu);
+    renderer.domElement.addEventListener('click', handleLightGridClick);
+    // Blueprint mode: click on 3D viewport to select child components
+    renderer.domElement.addEventListener('click', (event) => {
+        if (!blueprintState.active) return;
+        if (event.button !== 0) return;
+        if (typeof transformControl !== 'undefined' && (transformControl.dragging || transformControl.justFinishedDragging || transformControl.axis !== null)) return;
+        if (isTransformControlSphereHit(event)) return;
+        
+        const rect = renderer.domElement.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) return;
+        
+        pointerNdc.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+        pointerNdc.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+        raycaster.setFromCamera(pointerNdc, camera);
+        
+        const rootMesh = getActorRenderObject(blueprintState.targetActor);
+        if (!rootMesh) return;
+        
+        // Collect all meshes and lights in the actor tree
+        const allChildren = [];
+        rootMesh.traverse((child) => {
+            if (child.isMesh || child.isLight) allChildren.push(child);
+        });
+        
+        const hits = raycaster.intersectObjects(allChildren, false);
+        if (hits.length > 0) {
+            const hitObj = hits[0].object;
+            blueprintState.selectedComponent = hitObj;
+            blueprintState.selectedComponents.clear();
+            blueprintState.materialMultiSelectActive = false;
+            if (hitObj.isMesh) blueprintState.selectedComponents.add(hitObj);
+            if (typeof transformControl !== 'undefined') transformControl.attach(hitObj);
+            refreshBlueprintComponents();
+        }
+    });
+    
+    renderer.domElement.addEventListener('dblclick', (event) => {
+        // Blueprint mode: double-click to focus camera on a component
+        if (blueprintState.active) {
+            const rect = renderer.domElement.getBoundingClientRect();
+            if (rect.width <= 0 || rect.height <= 0) return;
+            pointerNdc.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+            pointerNdc.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+            raycaster.setFromCamera(pointerNdc, camera);
+            
+            const rootMesh = getActorRenderObject(blueprintState.targetActor);
+            if (!rootMesh) return;
+            const allChildren = [];
+            rootMesh.traverse((child) => {
+                if (child.isMesh || child.isLight) allChildren.push(child);
+            });
+            
+            const hits = raycaster.intersectObjects(allChildren, false);
+            if (hits.length > 0) {
+                const hitObj = hits[0].object;
+                blueprintState.selectedComponent = hitObj;
+                blueprintState.selectedComponents.clear();
+                blueprintState.materialMultiSelectActive = false;
+                if (hitObj.isMesh) blueprintState.selectedComponents.add(hitObj);
+                if (typeof transformControl !== 'undefined') transformControl.attach(hitObj);
+                refreshBlueprintComponents();
+                
+                focusShowcaseCameraOnObject(hitObj, { duration: 0.5 });
+            }
+            return;
+        }
+        
+        if (gameplay.active) return;
+        const propHit = getDynamicPropHitFromEvent(event);
+        if (propHit?.prop) {
+            selectShowcaseActor(propHit.prop.id, propHit.hit?.object ?? null);
+            focusShowcaseCameraOnObject(propHit.hit?.object ?? getActorRenderObject(propHit.prop), { duration: 0.55 });
+            
+            if (getSceneUiList()) {
+                const activeItem = getSceneUiList().querySelector(`[data-id="${propHit.prop.id}"]`);
+                if (activeItem) {
+                    activeItem.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }
+            }
+        }
+    });
+    renderer.domElement.addEventListener('pointerdown', (event) => {
+        if (event.pointerType === 'mouse') return;
+        if (gameplay.active) {
+            if (runMouseAction('left', event)) {
+                event.preventDefault();
+            }
+            return;
+        }
+        if (maybeOpenObjectScriptMenuFromMobileTap(event)) {
+            const focusedProp = getDynamicPropById(objectScriptState.targetPropId);
+            focusShowcaseCameraOnObject(getActorRenderObject(focusedProp), { duration: 0.55 });
+            event.preventDefault();
+        }
+    }, { passive: false });
+}
+
+export function adjustShowcaseSpeed(direction) {
+    const factor = direction > 0 ? showcase.wheelSpeedStep : 1 / showcase.wheelSpeedStep;
+    showcase.moveSpeed = THREE.MathUtils.clamp(
+        showcase.moveSpeed * factor,
+        showcase.minMoveSpeed,
+        showcase.maxMoveSpeed
+    );
+    updateGameplayUI();
+}
+
+export function updateShowcaseInput(event, isDown) {
+    if (!showcase.looking && (event.code === 'KeyE' || event.code === 'KeyQ' || event.code === 'Space' || event.code === 'ControlLeft' || event.code === 'ControlRight')) {
+        return false;
+    }
+    switch (event.code) {
+        case 'KeyW':
+        case 'ArrowUp':
+            showcase.input.forward = isDown;
+            return true;
+        case 'KeyS':
+        case 'ArrowDown':
+            showcase.input.back = isDown;
+            return true;
+        case 'KeyA':
+        case 'ArrowLeft':
+            showcase.input.left = isDown;
+            return true;
+        case 'KeyD':
+        case 'ArrowRight':
+            showcase.input.right = isDown;
+            return true;
+        case 'KeyE':
+        case 'Space':
+            showcase.input.up = isDown;
+            return true;
+        case 'KeyQ':
+        case 'ControlLeft':
+        case 'ControlRight':
+            showcase.input.down = isDown;
+            return true;
+        case 'ShiftLeft':
+        case 'ShiftRight':
+            showcase.input.boost = isDown;
+            return true;
+        default:
+            return false;
+    }
+}
+
+export function handleGameplayKeyEvent(event) {
+    const isDown = event.type === 'keydown';
+    const eventTarget = event.target instanceof HTMLElement ? event.target : document.activeElement;
+
+    if (debugConsoleState.visible) {
+        if (gameplay.pointerLocked || gameplay.active) {
+            event.preventDefault();
+        }
+        return;
+    }
+
+    if (isDown && !event.repeat && event.code === 'F8') {
+        setCollisionDebugEnabled(!collisionDebugState.enabled);
+        event.preventDefault();
+        return;
+    }
+
+    if (isDown && !event.repeat && event.code === 'KeyL' && !isEditableElement(eventTarget)) {
+        void playAudioTestCue();
+        event.preventDefault();
+        return;
+    }
+
+    if (!gameplay.active && !gameplay.pointerLocked && isDown) {
+        if (event.code === 'Delete') {
+            if (blueprintState.active) {
+                editorHistory.captureState();
+                document.getElementById('btn-delete-comp')?.click();
+            } else {
+                deleteSelectedActor();
+            }
+            return;
+        }
+        if (event.ctrlKey || event.metaKey) {
+            if (event.code === 'KeyC') {
+                copySelectedToClipboard();
+                return;
+            } else if (event.code === 'KeyV') {
+                pasteFromClipboard();
+                return;
+            } else if (event.code === 'KeyZ') {
+                if (event.shiftKey) {
+                    editorHistory.redo();
+                } else {
+                    editorHistory.undo();
+                }
+                return;
+            } else if (event.code === 'KeyY') {
+                editorHistory.redo();
+                return;
+            } else if (event.code === 'KeyD') {
+                duplicateSelected();
+                event.preventDefault();
+                return;
+            }
+        }
+        if (!showcase.looking && event.code === 'KeyW') {
+            transformControl?.setMode('translate');
+            if (blueprintState.active) updateBlueprintTransformUI();
+        } else if (!showcase.looking && event.code === 'KeyE') {
+            transformControl?.setMode('rotate');
+            if (blueprintState.active) updateBlueprintTransformUI();
+        } else if (!showcase.looking && event.code === 'KeyR') {
+            transformControl?.setMode('scale');
+            if (blueprintState.active) updateBlueprintTransformUI();
+        } else if (!showcase.looking && event.code === 'Backquote') { // Tilde key for toggling space
+            if (transformControl) {
+                transformControl.setSpace(transformControl.space === 'local' ? 'world' : 'local');
+                if (blueprintState.active) updateBlueprintTransformUI();
+            }
+        }
+    }
+
+    if (!gameplay.active && !gameplay.pointerLocked) {
+        const acceptsShowcaseInput = renderer && (showcase.looking || document.activeElement === renderer.domElement);
+        if (acceptsShowcaseInput && updateShowcaseInput(event, isDown)) {
+            event.preventDefault();
+            return;
+        }
+    }
+
+    if (!gameplay.canPlay) return;
+
+    switch (event.code) {
+        case 'KeyW':
+        case 'ArrowUp':
+            gameplay.input.forward = isDown;
+            break;
+        case 'KeyS':
+        case 'ArrowDown':
+            gameplay.input.back = isDown;
+            break;
+        case 'KeyA':
+        case 'ArrowLeft':
+            gameplay.input.left = isDown;
+            break;
+        case 'KeyD':
+        case 'ArrowRight':
+            gameplay.input.right = isDown;
+            break;
+        case 'ShiftLeft':
+        case 'ShiftRight':
+            gameplay.input.sprint = isDown;
+            break;
+        case 'Space':
+            if (gameplay.pointerLocked) event.preventDefault();
+            if (isDown && !event.repeat && gameplay.active) {
+                if (isDrivingVehicle()) {
+                    vehicleState.brakeHeld = true;
+                } else {
+                    physics.jumpQueued = true;
+                }
+            } else if (!isDown) {
+                vehicleState.brakeHeld = false;
+            }
+            break;
+        case 'KeyE':
+            if (isDown && !event.repeat && gameplay.active) {
+                if (isDrivingVehicle()) {
+                    exitVehicle();
+                } else {
+                    enterVehicle();
+                }
+            }
+            break;
+        case 'KeyV':
+            if (isDown && !event.repeat && gameplay.active) {
+                spawnDrivableCar();
+            }
+            break;
+        case 'KeyR':
+            if (isDown && gameplay.active) {
+                if (isDrivingVehicle()) {
+                    exitVehicle();
+                }
+                respawnPlayer();
+            }
+            break;
+        default:
+            return;
+    }
+
+    if (gameplay.pointerLocked) {
+        event.preventDefault();
+    }
+}
+
+export function handleGameplayMouseMove(event) {
+    if (!gameplay.pointerLocked) {
+        if (terrainBrushState.enabled && !showcase.looking && !blueprintState.active && !gameplay.active) {
+            if (terrainBrushState.active) {
+                applyTerrainBrushFromEvent(event);
+            } else {
+                updateTerrainBrushPreview(event);
+            }
+            return;
+        }
+        if (!showcase.looking || gameplay.active) return;
+
+        showcase.yaw -= event.movementX * 0.0022;
+        showcase.pitch -= event.movementY * 0.0018;
+        showcase.pitch = THREE.MathUtils.clamp(
+            showcase.pitch,
+            -PLAYER_SETTINGS.maxLookPitch,
+            PLAYER_SETTINGS.maxLookPitch
+        );
+
+        applyShowcaseCameraRotation();
+        return;
+    }
+
+    gameplay.yaw -= event.movementX * 0.0022;
+    gameplay.pitch -= event.movementY * 0.0018;
+    gameplay.pitch = THREE.MathUtils.clamp(
+        gameplay.pitch,
+        -PLAYER_SETTINGS.maxLookPitch,
+        PLAYER_SETTINGS.maxLookPitch
+    );
+
+    applyGameplayCameraRotation();
+}
+
+export function handleShowcaseMouseButton(event) {
+    // In blueprint mode, don't let the normal actor selection logic
+    // intercept clicks — TransformControls needs those events for gizmo drag
+    if (blueprintState.active) {
+        if (event.type === 'mousedown' && event.button === 2) {
+            showcase.looking = true;
+            event.preventDefault();
+        } else if (event.type === 'mouseup' && event.button === 2) {
+            showcase.looking = false;
+        }
+        return;
+    }
+
+    if (gameplay.active) {
+        if (event.type === 'mousedown') {
+            const buttonName = event.button === 2 ? 'right' : event.button === 0 ? 'left' : null;
+            if (buttonName) {
+                runMouseAction(buttonName, event);
+            }
+        }
+        return;
+    }
+
+    if (gameplay.active || gameplay.pointerLocked || !renderer) return;
+
+    if (event.type === 'mousedown') {
+        renderer.domElement.focus();
+        if (terrainBrushState.enabled && event.button === 0) {
+            terrainBrushState.active = true;
+            applyTerrainBrushFromEvent(event);
+            event.preventDefault();
+            return;
+        }
+        if (event.button === 0 && objectScriptState.menuOpen) {
+            closeObjectScriptMenu();
+        }
+        // Left-click: select actor and attach gizmo
+        if (event.button === 0) {
+            if (isTransformControlSphereHit(event)) {
+                event.preventDefault();
+                return;
+            }
+            const propHit = getDynamicPropHitFromEvent(event);
+            if (propHit?.prop) {
+                selectShowcaseActor(propHit.prop.id, propHit.hit?.object ?? null);
+            } else {
+                // Clicked empty space — deselect
+                selectShowcaseActor(null);
+            }
+            return;
+        }
+        if (event.button !== 2) return;
+        closeObjectScriptMenu();
+        showcase.looking = true;
+        event.preventDefault();
+        return;
+    }
+
+    if (event.button === 0 && terrainBrushState.active) {
+        terrainBrushState.active = false;
+        if (terrainBrushState.dirtyPhysics) {
+            rebuildTerrainPhysicsBody();
+            terrainBrushState.dirtyPhysics = false;
+        }
+        event.preventDefault();
+        return;
+    }
+
+    if (event.button === 2) {
+        showcase.looking = false;
+    }
+}
+
+export function handleShowcaseContextMenu(event) {
+    if (gameplay.active || gameplay.pointerLocked || !renderer) {
+        event.preventDefault();
+        return;
+    }
+
+    if (isTransformControlSphereHit(event)) {
+        event.preventDefault();
+        return;
+    }
+
+    event.preventDefault();
+    closeObjectScriptMenu();
+}
+
+export function handleShowcaseWheel(event) {
+    if (gameplay.active || gameplay.pointerLocked) return;
+
+    event.preventDefault();
+    adjustShowcaseSpeed(event.deltaY < 0 ? 1 : -1);
+}
+
+export function handlePointerLockChange() {
+    const isLocked = document.pointerLockElement === renderer.domElement;
+
+    if (isLocked) {
+        gameplay.pointerLocked = true;
+        gameplay.active = true;
+        showcase.looking = false;
+        syncTransformControlState();
+        closeObjectScriptMenu();
+        closeObjectScriptEditor();
+        updateWorldPresentation();
+        updateGameplayUI();
+        renderer.domElement.focus();
+        return;
+    }
+
+    if (!gameplay.pointerLocked && !gameplay.active) return;
+
+    gameplay.pointerLocked = false;
+    gameplay.active = false;
+    gameplay.velocity.set(0, 0, 0);
+    physics.desiredVelocity.set(0, 0, 0);
+    resetMovementInputState();
+    restoreSceneState();
+    syncTransformControlState();
+
+    updateWorldPresentation();
+    resetShowcaseCamera(false);
+    updateGameplayUI();
+}
+
+export function enterGameplay() {
+    if (!gameplay.canPlay && physics.ready) {
+        gameplay.canPlay = true;
+        ensurePlayerCharacter();
+    }
+    if (!gameplay.canPlay) return;
+
+    snapshotSceneState();
+    syncGameplaySpawnToCamera();
+    respawnPlayer(true);
+    gameplay.pointerLocked = false;
+    gameplay.active = true;
+    syncTransformControlState();
+    resetAllScriptLifecycleHandles();
+    applyMouseActionScripts({ persist: true });
+    showcase.looking = false;
+    resetMobileInputState();
+    updateWorldPresentation();
+    updateGameplayUI();
+
+    if (!mobileState.enabled) {
+        renderer.domElement.requestPointerLock?.();
+    }
+}
+
+export function exitGameplay() {
+    if (!mobileState.enabled && document.pointerLockElement === renderer.domElement) {
+        document.exitPointerLock();
+        return;
+    }
+
+    if (!gameplay.active && !gameplay.pointerLocked) return;
+
+    gameplay.pointerLocked = false;
+    gameplay.active = false;
+    clearActiveVehicle();
+    restoreSceneState();
+    gameplay.velocity.set(0, 0, 0);
+    physics.jumpQueued = false;
+    physics.desiredVelocity.set(0, 0, 0);
+    showcase.looking = false;
+    showcase.velocity.set(0, 0, 0);
+    showcase.input.forward = false;
+    showcase.input.back = false;
+    showcase.input.left = false;
+    showcase.input.right = false;
+    showcase.input.up = false;
+    showcase.input.down = false;
+    showcase.input.boost = false;
+    resetMobileInputState();
+    syncTransformControlState();
+
+    updateWorldPresentation();
+    resetShowcaseCamera(false);
+    updateGameplayUI();
+}
+
+export function forceExitGameplayForWorldLoad() {
+    if (!mobileState.enabled && document.pointerLockElement === renderer?.domElement) {
+        document.exitPointerLock?.();
+    }
+
+    gameplay.pointerLocked = false;
+    gameplay.active = false;
+    clearActiveVehicle();
+    gameplay.velocity.set(0, 0, 0);
+    physics.jumpQueued = false;
+    physics.desiredVelocity.set(0, 0, 0);
+    showcase.looking = false;
+    showcase.velocity.set(0, 0, 0);
+    resetMobileInputState();
+    syncTransformControlState();
+    updateWorldPresentation();
+    updateGameplayUI();
+}
+
+export function updateWorldPresentation() {
+    if (getPedestal()) getPedestal().visible = !gameplay.active;
+    document.body.classList.toggle('play-ready', gameplay.canPlay);
+    const wasActive = document.body.classList.contains('play-active');
+    document.body.classList.toggle('play-active', gameplay.active);
+    if (wasActive !== gameplay.active && renderer && camera && container) {
+        // Layout shifts when scene panel hides; resync canvas/aspect.
+        requestAnimationFrame(onWindowResize);
+    }
+}
+
+export function updateMainDirectionalLightShadowFocus() {
+    if (!getMainDirectionalLight() || !camera) return;
+
+    mainDirectionalLightShadowFocus.copy(camera.position);
+    mainDirectionalLightShadowFocus.y = getWorldFloor()?.position?.y ?? 0;
+
+    getMainDirectionalLight().position.copy(mainDirectionalLightShadowFocus).add(mainDirectionalLightOffset);
+    getMainDirectionalLight().target.position.copy(mainDirectionalLightShadowFocus);
+    getMainDirectionalLight().target.updateMatrixWorld();
+}
+
+export function updateGameplayUI() {
+    const hasAsset = !!getCurrentMesh();
+    const mobileActive = mobileState.enabled;
+    const drivingVehicle = isDrivingVehicle();
+
+    if (getResetViewBtn()) {
+        getResetViewBtn().textContent = gameplay.active ? 'Respawn' : 'Reset View';
+    }
+
+    updateCameraModeButtons();
+
+    if (getGameplayStatus()) {
+        if (mobileActive && drivingVehicle) {
+            getGameplayStatus().textContent = 'Mobile driving active';
+        } else if (mobileActive && gameplay.active) {
+            getGameplayStatus().textContent = 'Mobile play active';
+        } else if (mobileActive) {
+            getGameplayStatus().textContent = 'Mobile showcase ready';
+        } else if (drivingVehicle) {
+            getGameplayStatus().textContent = 'Driving summoned car';
+        } else if (!hasAsset && gameplay.active) {
+            getGameplayStatus().textContent = gameplay.grounded ? 'Exploring terrain' : 'Airborne';
+        } else if (!hasAsset) {
+            getGameplayStatus().textContent = `Showcase free-fly ready. Camera speed ${showcase.moveSpeed.toFixed(1)}x.`;
+        } else if (gameplay.active) {
+            getGameplayStatus().textContent = gameplay.grounded ? 'Exploring scene' : 'Airborne';
+        } else {
+            getGameplayStatus().textContent = `Scene ready. Showcase speed ${showcase.moveSpeed.toFixed(1)}x.`;
+        }
+    }
+
+    if (getPlayHint()) {
+        if (mobileActive && drivingVehicle) {
+            getPlayHint().textContent = 'Touch left pad to drive, right pad to look, hold Brake to slow down, tap the scene for play scripts, and tap E on keyboard to hop out.';
+        } else if (mobileActive && gameplay.active) {
+            getPlayHint().textContent = 'Touch left pad to move, right pad to look, tap the scene to run play scripts, and use Jump to hop.';
+        } else if (mobileActive) {
+            getPlayHint().textContent = 'Touch left pad to move, right pad to look, double-tap a prop to open its script menu, and use Menu for assets.';
+        } else if (drivingVehicle) {
+            getPlayHint().textContent = 'W/S drive, A/D steer, Shift boost, Space brake, E exit car, R respawn, Esc exit play mode.';
+        } else if (!hasAsset && gameplay.active) {
+            getPlayHint().textContent = 'WASD move, mouse look, Space jump, Shift sprint, E enter nearby car, V summon car, R respawn, Esc exit.';
+        } else if (!hasAsset) {
+            getPlayHint().textContent = 'Showcase: hold right mouse to look, use WASD to move, Q/E for down/up, Shift to boost, and mouse wheel to change camera speed.';
+        } else if (gameplay.active) {
+            getPlayHint().textContent = 'WASD move, mouse look, Space jump, Shift sprint, E enter nearby car, V summon car, R respawn, Esc exit.';
+        } else {
+            getPlayHint().textContent = 'Showcase: hold right mouse to look, use WASD to move, Q/E for down/up, Shift to boost, and mouse wheel to change camera speed. Play mode still uses pointer lock.';
+        }
+    }
+
+    updateMobileButtons();
+    updateMouseActionStatus();
+    updateWorldPresentation();
+}
+
+export function getShowcaseTarget() {
+    if (!getCurrentMesh()) {
+        return SHOWCASE_CAMERA_TARGET;
+    }
+
+    return tempVectorA.set(
+        gameplayLookTarget.x,
+        Math.max(1.25, gameplayBounds.max.y * 0.35),
+        gameplayLookTarget.z
+    );
+}
+
+export function resetShowcaseCamera(animate = true) {
+    if (gameplay.active) return;
+
+    const target = getShowcaseTarget();
+    const animatedLookTarget = {
+        x: camera.position.x,
+        y: camera.position.y,
+        z: camera.position.z,
+    };
+
+    if (!animate) {
+        camera.position.copy(SHOWCASE_CAMERA_POSITION);
+        syncShowcaseAnglesFromTarget(target);
+        applyShowcaseCameraRotation();
+        showcase.velocity.set(0, 0, 0);
+        return;
+    }
+
+    gsap.killTweensOf(camera.position);
+    gsap.killTweensOf(animatedLookTarget);
+
+    gsap.to(camera.position, {
+        x: SHOWCASE_CAMERA_POSITION.x,
+        y: SHOWCASE_CAMERA_POSITION.y,
+        z: SHOWCASE_CAMERA_POSITION.z,
+        duration: 0.9,
+        overwrite: true,
+        onUpdate: () => {
+            syncShowcaseAnglesFromTarget(tempVectorB.set(animatedLookTarget.x, animatedLookTarget.y, animatedLookTarget.z));
+            applyShowcaseCameraRotation();
+        },
+    });
+
+    gsap.to(animatedLookTarget, {
+        x: target.x,
+        y: target.y,
+        z: target.z,
+        duration: 0.9,
+        overwrite: true,
+        onUpdate: () => {
+            syncShowcaseAnglesFromTarget(tempVectorB.set(animatedLookTarget.x, animatedLookTarget.y, animatedLookTarget.z));
+            applyShowcaseCameraRotation();
+        },
+    });
+}
+
+export function updateShowcaseCamera(delta) {
+    const moveRight = (showcase.input.right ? 1 : 0) - (showcase.input.left ? 1 : 0);
+    const moveForward = (showcase.input.forward ? 1 : 0) - (showcase.input.back ? 1 : 0);
+    const moveVertical = (showcase.input.up ? 1 : 0) - (showcase.input.down ? 1 : 0);
+
+    tempVectorA.set(0, 0, 0);
+    camera.getWorldDirection(tempVectorB);
+
+    if (tempVectorB.lengthSq() < 1e-6) {
+        tempVectorB.set(0, 0, -1);
+    } else {
+        tempVectorB.normalize();
+    }
+
+    tempVectorC.crossVectors(tempVectorB, upVector).normalize();
+
+    tempVectorA
+        .addScaledVector(tempVectorC, moveRight)
+        .addScaledVector(tempVectorB, moveForward)
+        .addScaledVector(upVector, moveVertical);
+
+    if (tempVectorA.lengthSq() > 0) {
+        tempVectorA.normalize();
+    }
+
+    const moveSpeed = showcase.moveSpeed * (showcase.input.boost ? showcase.boostMultiplier : 1);
+    showcase.velocity.lerp(tempVectorA.multiplyScalar(moveSpeed), tempVectorA.lengthSq() > 0 ? 0.35 : 0.18);
+
+    if (showcase.velocity.lengthSq() < 1e-5) {
+        showcase.velocity.set(0, 0, 0);
+        return;
+    }
+
+    camera.position.addScaledVector(showcase.velocity, delta);
+}
+
+export function respawnPlayer(useStoredView = false) {
+    if (!gameplay.canPlay && physics.ready) {
+        gameplay.canPlay = true;
+    }
+    if (!gameplay.canPlay) return;
+
+    if (isDrivingVehicle()) {
+        clearActiveVehicle();
+    }
+
+    if (!physics.character) {
+        ensurePlayerCharacter();
+    }
+
+    if (!physics.character) return;
+
+    const spawnPosition = new physics.Jolt.RVec3(
+        gameplay.spawnPoint.x,
+        gameplay.spawnPoint.y,
+        gameplay.spawnPoint.z
+    );
+    physics.character.SetPosition(spawnPosition);
+    physics.Jolt.destroy(spawnPosition);
+    physics.character.SetLinearVelocity(physics.Jolt.Vec3.prototype.sZero());
+    gameplay.velocity.set(0, 0, 0);
+    gameplay.grounded = true;
+
+    if (useStoredView) {
+        gameplay.yaw = gameplay.spawnYaw;
+        gameplay.pitch = gameplay.spawnPitch;
+    }
+
+    syncCameraToCharacter();
+
+    if (!useStoredView) {
+        tempVectorA.copy(gameplayLookTarget).sub(camera.position);
+        const flatDistance = Math.max(0.001, Math.hypot(tempVectorA.x, tempVectorA.z));
+        gameplay.yaw = Math.atan2(tempVectorA.x, tempVectorA.z);
+        gameplay.pitch = THREE.MathUtils.clamp(
+            Math.atan2(-tempVectorA.y, flatDistance),
+            -PLAYER_SETTINGS.maxLookPitch,
+            PLAYER_SETTINGS.maxLookPitch
+        );
+        gameplay.spawnYaw = gameplay.yaw;
+        gameplay.spawnPitch = gameplay.pitch;
+    }
+
+    applyGameplayCameraRotation();
+    updateGameplayUI();
+}
+
+export function applyGameplayCameraRotation() {
+    camera.rotation.order = 'YXZ';
+    camera.rotation.x = gameplay.pitch;
+    camera.rotation.y = gameplay.yaw;
+    camera.rotation.z = 0;
+}
+
+export function resolveHorizontalMovement(origin, movementDelta) {
+    if (!getCurrentMesh() || movementDelta.lengthSq() === 0) {
+        return movementDelta;
+    }
+
+    const adjustedMovement = movementDelta.clone();
+    const direction = tempVectorA.copy(movementDelta).normalize();
+    const probeHeights = [PLAYER_SETTINGS.eyeHeight * 0.35, PLAYER_SETTINGS.eyeHeight * 0.75];
+
+    for (const probeHeight of probeHeights) {
+        const rayOrigin = tempVectorB.copy(origin);
+        rayOrigin.y += probeHeight - PLAYER_SETTINGS.eyeHeight;
+
+        raycaster.set(rayOrigin, direction);
+
+        const hit = raycaster.intersectObject(getCurrentMesh(), true).find(entry => (
+            entry.distance <= movementDelta.length() + PLAYER_SETTINGS.collisionRadius
+        ));
+        updateRaycasterDebugLine(
+            raycaster.ray,
+            movementDelta.length() + PLAYER_SETTINGS.collisionRadius,
+            hit?.point ?? null,
+            !!hit,
+        );
+
+        if (!hit || !hit.face) continue;
+
+        const wallNormal = hit.face.normal.clone().transformDirection(hit.object.matrixWorld);
+        if (wallNormal.y > 0.6) continue;
+
+        adjustedMovement.projectOnPlane(wallNormal);
+        adjustedMovement.addScaledVector(wallNormal, PLAYER_SETTINGS.wallClearance);
+    }
+
+    return adjustedMovement;
+}
+
+export function updateGameplay(delta) {
+    if (isDrivingVehicle()) {
+        updateVehicleGameplay(delta);
+        return;
+    }
+
+    silenceVehicleEngineAudio();
+    updateEngineAudioDebugOverlay('idle', null, null);
+
+    if (!physics.character) return;
+
+    const moveRight = (gameplay.input.right ? 1 : 0) - (gameplay.input.left ? 1 : 0);
+    const moveForward = (gameplay.input.forward ? 1 : 0) - (gameplay.input.back ? 1 : 0);
+    const moveSpeed = gameplay.input.sprint ? PLAYER_SETTINGS.sprintSpeed : PLAYER_SETTINGS.walkSpeed;
+    const wasGrounded = gameplay.grounded;
+
+    tempVectorA.set(0, 0, 0);
+    if (moveRight !== 0 || moveForward !== 0) {
+        camera.getWorldDirection(tempVectorB);
+        tempVectorB.y = 0;
+
+        if (tempVectorB.lengthSq() < 1e-6) {
+            tempVectorB.set(0, 0, -1);
+        } else {
+            tempVectorB.normalize();
+        }
+
+        tempVectorC.crossVectors(tempVectorB, upVector).normalize();
+
+        tempVectorA
+            .addScaledVector(tempVectorC, moveRight)
+            .addScaledVector(tempVectorB, moveForward);
+
+        if (tempVectorA.lengthSq() > 0) {
+            tempVectorA.normalize().multiplyScalar(moveSpeed);
+        }
+    }
+
+    const desiredMovement = tempVectorE.copy(tempVectorA);
+
+    physics.character.UpdateGroundVelocity();
+
+    const linearVelocity = copyJoltVector(tempVectorB, physics.character.GetLinearVelocity());
+    const currentVerticalVelocity = tempVectorC.copy(upVector).multiplyScalar(linearVelocity.dot(upVector));
+    const currentHorizontalVelocity = tempVectorD.copy(linearVelocity).sub(currentVerticalVelocity);
+    const groundVelocity = copyJoltVector(tempVectorA, physics.character.GetGroundVelocity());
+
+    const onGround = physics.character.IsSupported();
+    const movingTowardsGround = currentVerticalVelocity.y - groundVelocity.y <= 0.1;
+    physics.allowSliding = desiredMovement.lengthSq() > 1e-8;
+
+    let nextVelocity;
+    if (onGround && movingTowardsGround) {
+        nextVelocity = groundVelocity.clone();
+        if (physics.jumpQueued) {
+            nextVelocity.y += PLAYER_SETTINGS.jumpSpeed;
+        }
+    } else {
+        nextVelocity = currentVerticalVelocity.clone();
+    }
+
+    nextVelocity.addScaledVector(copyJoltVector(tempVectorC, physics.gravity), delta);
+
+    if (physics.allowSliding) {
+        physics.desiredVelocity.lerp(desiredMovement, onGround ? 0.32 : 0.12);
+        nextVelocity.add(physics.desiredVelocity);
+    } else if (!onGround) {
+        nextVelocity.add(currentHorizontalVelocity);
+        physics.desiredVelocity.multiplyScalar(0.92);
+    } else {
+        physics.desiredVelocity.multiplyScalar(0.2);
+    }
+
+    const nextVelocityJolt = new physics.Jolt.Vec3(nextVelocity.x, nextVelocity.y, nextVelocity.z);
+    physics.character.SetLinearVelocity(nextVelocityJolt);
+    physics.Jolt.destroy(nextVelocityJolt);
+    physics.character.ExtendedUpdate(
+        delta,
+        physics.gravity,
+        physics.updateSettings,
+        physics.movingBroadPhaseFilter,
+        physics.movingLayerFilter,
+        physics.bodyFilter,
+        physics.shapeFilter,
+        physics.jolt.GetTempAllocator()
+    );
+
+    syncCameraToCharacter();
+    applyGameplayCameraRotation();
+    gameplay.grounded = physics.character.IsSupported();
+    physics.jumpQueued = false;
+
+    const characterPosition = copyJoltVector(tempVectorA, physics.character.GetPosition());
+    if (characterPosition.y < getWorldFloor().position.y - 24) {
+        respawnPlayer();
+    }
+
+    if (wasGrounded !== gameplay.grounded) {
+        updateGameplayUI();
+    }
+}
+
+export function syncGameplaySpawnToCamera() {
+    if (!camera) return;
+
+    gameplay.spawnPoint.set(
+        camera.position.x,
+        camera.position.y - PLAYER_SETTINGS.eyeHeight,
+        camera.position.z
+    );
+
+    tempVectorA.setFromEuler(camera.rotation.reorder('YXZ'));
+    gameplay.spawnYaw = tempVectorA.y;
+    gameplay.spawnPitch = THREE.MathUtils.clamp(
+        tempVectorA.x,
+        -PLAYER_SETTINGS.maxLookPitch,
+        PLAYER_SETTINGS.maxLookPitch
+    );
+}
+
+export function syncShowcaseAnglesFromTarget(target) {
+    tempVectorA.copy(target).sub(camera.position);
+    const flatDistance = Math.max(0.001, Math.hypot(tempVectorA.x, tempVectorA.z));
+    showcase.yaw = Math.atan2(tempVectorA.x, tempVectorA.z);
+    showcase.pitch = THREE.MathUtils.clamp(
+        Math.atan2(-tempVectorA.y, flatDistance),
+        -PLAYER_SETTINGS.maxLookPitch,
+        PLAYER_SETTINGS.maxLookPitch
+    );
+}
+
+export function syncShowcaseAnglesToFaceTarget(target) {
+    tempVectorA.copy(target).sub(camera.position);
+    const flatDistance = Math.max(0.001, Math.hypot(tempVectorA.x, tempVectorA.z));
+    showcase.yaw = Math.atan2(-tempVectorA.x, -tempVectorA.z);
+    showcase.pitch = THREE.MathUtils.clamp(
+        Math.atan2(tempVectorA.y, flatDistance),
+        -PLAYER_SETTINGS.maxLookPitch,
+        PLAYER_SETTINGS.maxLookPitch
+    );
+}
+
+export function applyShowcaseCameraRotation() {
+    camera.rotation.order = 'YXZ';
+    camera.rotation.x = showcase.pitch;
+    camera.rotation.y = showcase.yaw;
+    camera.rotation.z = 0;
+}

--- a/src/io/dropHandlers.js
+++ b/src/io/dropHandlers.js
@@ -1,0 +1,230 @@
+// src/io/dropHandlers.js
+// Extracted from main.js (chore/main-js-shrink-2). Owns the file-drop / dropdown
+// loader, the OBJ/GLB/UMAP/FBX dispatcher, the loader scan effect, and the
+// per-frame onWindowResize hook. `currentMesh` and `modelBody` are owned by
+// main.js and come through as get/set callbacks because they get reassigned
+// inside loadModel + clearCurrentMesh.
+
+import * as THREE from 'three';
+import gsap from 'gsap';
+
+let scene, camera, renderer, container;
+let physics, gameplay;
+let processingOverlay, processingStep, loaderBar;
+let MODEL_TARGET_MAX_DIMENSION;
+let getCurrentMesh, setCurrentMesh, getModelBody, setModelBody;
+let getScanPlane, setScanPlane;
+let loadObjectFromFile, normalizeObjectToDimension;
+let clearDynamicPhysicsProps, destroyPhysicsBody, destroyPlayerCharacter;
+let disposeRenderableObject, playObjectAnimation;
+let updateLoadedAssetStats, refreshGameplayWorld, updateGameplayUI, exitGameplay;
+
+export function installDropHandlers(deps) {
+    ({
+        scene, camera, renderer, container,
+        physics, gameplay,
+        processingOverlay, processingStep, loaderBar,
+        MODEL_TARGET_MAX_DIMENSION,
+        getCurrentMesh, setCurrentMesh, getModelBody, setModelBody,
+        getScanPlane, setScanPlane,
+        loadObjectFromFile, normalizeObjectToDimension,
+        clearDynamicPhysicsProps, destroyPhysicsBody, destroyPlayerCharacter,
+        disposeRenderableObject, playObjectAnimation,
+        updateLoadedAssetStats, refreshGameplayWorld, updateGameplayUI, exitGameplay,
+    } = deps);
+}
+
+export function onWindowResize() {
+    camera.aspect = container.clientWidth / container.clientHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(container.clientWidth, container.clientHeight);
+}
+
+export function clearCurrentMesh() {
+    exitGameplay();
+    clearDynamicPhysicsProps();
+
+    if (physics.modelBody) {
+        destroyPhysicsBody(physics.modelBody);
+        physics.modelBody = null;
+    }
+    destroyPlayerCharacter();
+
+    if (!getCurrentMesh()) {
+        gameplay.canPlay = physics.ready;
+        updateGameplayUI();
+        return;
+    }
+
+    scene.remove(getCurrentMesh());
+    disposeRenderableObject(getCurrentMesh());
+
+    setCurrentMesh(null);
+    gameplay.canPlay = physics.ready;
+    updateGameplayUI();
+}
+
+export function normalizeCurrentMesh(targetDimension = MODEL_TARGET_MAX_DIMENSION) {
+    if (!getCurrentMesh()) return;
+    normalizeObjectToDimension(getCurrentMesh(), targetDimension, true);
+}
+
+export async function readDirectoryFiles(dirEntry) {
+    const fileMap = {};
+    const readEntries = (entry) => new Promise((resolve) => {
+        if (entry.isFile) {
+            entry.file(file => {
+                const url = URL.createObjectURL(file);
+                // Store by lowercase filename so we can match case-insensitively
+                fileMap[file.name.toLowerCase()] = { file, url };
+                resolve();
+            });
+        } else if (entry.isDirectory) {
+            const reader = entry.createReader();
+            const readBatch = () => {
+                reader.readEntries(async (entries) => {
+                    if (entries.length === 0) return resolve();
+                    await Promise.all(entries.map(readEntries));
+                    readBatch(); // keep reading until empty batch
+                });
+            };
+            readBatch();
+        } else {
+            resolve();
+        }
+    });
+    await readEntries(dirEntry);
+    return fileMap;
+}
+
+export function setupDropHandlers() {
+    container.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        container.classList.add('drag-active');
+    });
+
+    container.addEventListener('dragleave', (e) => {
+        if (e.relatedTarget && container.contains(e.relatedTarget)) return;
+        container.classList.remove('drag-active');
+    });
+
+    container.addEventListener('drop', async (e) => {
+        e.preventDefault();
+        container.classList.remove('drag-active');
+
+        const items = [...e.dataTransfer.items];
+        const firstEntry = items[0]?.webkitGetAsEntry?.();
+
+        // --- Folder drop ---
+        if (firstEntry?.isDirectory) {
+            processingStep.textContent = 'Reading folder...';
+            processingOverlay.style.display = 'flex';
+            loaderBar.style.width = '10%';
+
+            const fileMap = await readDirectoryFiles(firstEntry);
+            const modelEntry = Object.values(fileMap).find(({ file }) =>
+                /\.(fbx|glb|gltf|obj)$/i.test(file.name)
+            );
+            processingOverlay.style.display = 'none';
+
+            if (!modelEntry) {
+                alert('No supported 3D file found in folder (.glb, .gltf, .obj, .fbx)');
+                return;
+            }
+            loadModel(modelEntry.file, fileMap);
+            return;
+        }
+
+        // --- Multi-file drop (files dropped directly, no folder) ---
+        if (items.length > 1) {
+            processingStep.textContent = 'Reading files...';
+            processingOverlay.style.display = 'flex';
+            loaderBar.style.width = '10%';
+
+            const fileMap = {};
+            let mainFile = null;
+
+            for (let i = 0; i < e.dataTransfer.files.length; i++) {
+                const file = e.dataTransfer.files[i];
+                const url = URL.createObjectURL(file);
+                fileMap[file.name.toLowerCase()] = { file, url };
+                
+                if (/\.(fbx|glb|gltf|obj)$/i.test(file.name)) {
+                    mainFile = file;
+                }
+            }
+
+            processingOverlay.style.display = 'none';
+
+            if (!mainFile) {
+                alert('No supported 3D file found in dropped files (.glb, .gltf, .obj, .fbx)');
+                return;
+            }
+            loadModel(mainFile, fileMap);
+            return;
+        }
+
+        // --- Single file drop ---
+        const file = e.dataTransfer.files[0];
+        if (file && /\.(glb|gltf|obj|fbx)$/i.test(file.name)) {
+            loadModel(file, {});
+        } else {
+            alert('Please drop a .glb, .gltf, .obj, or .fbx file — or drag a whole folder to load FBX textures.');
+        }
+    });
+
+    const fileInput = document.getElementById('file-input');
+
+    fileInput.addEventListener('change', (e) => {
+        const file = e.target.files[0];
+        if (file) loadModel(file, {});
+    });
+}
+
+export async function loadModel(file, fileMap = {}) {
+    try {
+        const root = await loadObjectFromFile(file, fileMap);
+        clearCurrentMesh();
+        setCurrentMesh(root);
+        scene.add(getCurrentMesh());
+        normalizeCurrentMesh();
+        playObjectAnimation(getCurrentMesh());
+        refreshGameplayWorld();
+        updateLoadedAssetStats(file.name, file.size, getCurrentMesh());
+    } catch (error) {
+        console.error('Failed to load model.', error);
+        alert(error?.message === 'Unsupported file format'
+            ? 'Unsupported file format'
+            : 'Failed to load the selected model. Check the console for details.');
+    }
+}
+
+export function stopScanEffect() {
+    if (getScanPlane()) {
+        scene.remove(getScanPlane());
+        setScanPlane(null);
+    }
+}
+
+export function startScanEffect() {
+    const geometry = new THREE.PlaneGeometry(5, 5);
+    const material = new THREE.MeshBasicMaterial({
+        color: 0x00ffaa,
+        transparent: true,
+        opacity: 0.5,
+        side: THREE.DoubleSide,
+        blending: THREE.AdditiveBlending
+    });
+    setScanPlane(new THREE.Mesh(geometry, material));
+    getScanPlane().rotation.x = Math.PI / 2;
+    getScanPlane().position.y = -2;
+    scene.add(getScanPlane());
+
+    gsap.to(getScanPlane().position, {
+        y: 2,
+        duration: 2,
+        repeat: -1,
+        yoyo: true,
+        ease: "power1.inOut"
+    });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,60 +1,3756 @@
-import './style.css'
-import javascriptLogo from './assets/javascript.svg'
-import viteLogo from './assets/vite.svg'
-import heroImg from './assets/hero.png'
-import { setupCounter } from './counter.js'
+import * as THREE from 'three';
+import { WebGPURenderer, PostProcessing } from 'three/webgpu';
+import { pass, mrt, output, emissive, uniform } from 'three/tsl';
+import { bloom } from 'three/addons/tsl/display/BloomNode.js';
+import { TransformControls } from 'three/addons/controls/TransformControls.js';
+import * as BufferGeometryUtils from 'three/addons/utils/BufferGeometryUtils.js';
+import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
+import { MeshoptSimplifier } from 'meshoptimizer';
+import gsap from 'gsap';
+import {
+    WidgetManager,
+    BaseWidget,
+    TextWidget,
+    ImageWidget,
+    ProgressBarWidget,
+    ButtonWidget,
+} from './src/ui/widgets.js';
+import {
+    sampleTestTone,
+    writeWaveAscii,
+    createTestSoundBuffer,
+    createMediaTestSoundUrl,
+    createEngineNoiseBuffer,
+    createCombustionPulseBuffer,
+    createCombustionDistortionCurve,
+} from './src/audio/synthesis.js';
+import { createDrivableCarVisual } from './src/vehicle/visual.js';
+import { createVehicleFx } from './src/vehicle/fx.js';
+import {
+    setupVehicleController,
+    isDrivingVehicle, getActiveVehicleProp, clearActiveVehicle,
+    getVehicleForward, positionVehicleCamera, getNearbyVehicle,
+    enterVehicle, exitVehicle,
+    ensureVehicleVisualState, updateVehicleVisuals, updateVehicleGameplay,
+} from './src/vehicle/vehicleController.js';
+import {
+    installSceneUi,
+    formatPostProcessValue, clampPostProcessInput, readPostProcessInputValue,
+    updatePostProcessSliderLabels, updatePostProcessToggleUi, updatePostProcessStatusUi,
+    loadPostProcessInputsFromState, syncPostProcessVolumeUi, applyPostProcessSettingsFromUi,
+    syncActorEditorTemplateOptions, handleVehicleTemplateSelectChange, syncActorEditorUi,
+    closeActorEditor, openActorEditor, spawnActorFromEditor,
+    loadWorldEnvFromStorage, saveWorldEnvToStorage, applyWorldEnvState,
+    updateWorldEnvUi, setWorldEnvMaster, resetWorldEnvDefaults,
+    refreshSceneUI, createSceneActorItem,
+} from './src/editor/sceneUi.js';
+import {
+    installImportedProps,
+    enableOptimizationPipeline, updateLoadedAssetStats, updatePropImportStatus,
+    closePropCollisionPrompt, resolvePropCollisionPrompt, promptImportedPropCollision,
+    createImportedSimpleShape, createExactMeshShape, createImportedConvexHullShape,
+    collectImportedComplexHullParts, createImportedComplexShape, createImportedCollisionShape,
+    renderImportedPropButtons, registerImportedPropTemplate,
+    registerImportedPropTemplateFromSerializedData,
+    lookupBundleAsset, serializeImportedPropTemplate,
+    spawnImportedProp, importPhysicsProp,
+} from './src/world/importedProps.js';
+import {
+    installSceneExport,
+    runOptimizationPipeline, simplifyMesh, downloadAsset,
+    exportWorldToUmap, exportWorldToSceneFolder, exportRootToGlb,
+    writeFileToDirectory, downloadSceneFolderFallback,
+} from './src/optim/sceneExport.js';
+import {
+    installScriptState,
+    createDefaultObjectEventState, createObjectScriptState, sanitizeObjectScriptDrafts,
+    readObjectScriptDrafts, saveObjectScriptDrafts, ensureObjectScriptDraftEntry,
+    syncRuntimePropIdCounter, createRuntimePropId,
+    getActorScriptState, getActorMetadata, ensureActorIdentity, ensureActorScriptState,
+    resetAllScriptLifecycleHandles, registerCollisionForProp,
+    updateDynamicBodyCollisionScripts,
+    handleObjectScriptGlobalPointerDown, handleObjectScriptKeydown,
+} from './src/scripting/scriptState.js';
+import {
+    installSceneDebug,
+    ensureRaycastDebugLine, updateRaycastDebugLine, updateRaycasterDebugLine,
+    tickRaycastDebugLine,
+    createCollisionLineSegments, createCollisionOverlayFromObject,
+    createImportedSimpleCollisionOverlay, buildActorCollisionOverlay,
+    disposeCollisionOverlayObject, clearCollisionDebugOverlays, refreshCollisionDebugOverlays,
+    setCollisionDebugEnabled,
+    raycastWorld, describeRaycastHit, logGameplayDebugRayHit, updateGameplayDebugRay,
+    setRayDebugEnabled,
+    formatShadowDebugStatus, updateShadowDebugUi, isShadowForceExcludedObject,
+    forceAllSceneMeshShadows, setForceAllSceneMeshShadowsEnabled,
+    tickForceAllSceneMeshShadows,
+    updatePerfModeUi, setPerfModeEnabled,
+} from './src/debug/sceneDebug.js';
+import {
+    installDropHandlers,
+    readDirectoryFiles, setupDropHandlers, loadModel, onWindowResize,
+    stopScanEffect, startScanEffect, clearCurrentMesh, normalizeCurrentMesh,
+} from './src/io/dropHandlers.js';
+import {
+    installAnimatedSample,
+    makeAnimatedSampleQuatTrack, makeAnimatedSamplePart,
+    createAnimatedSampleModel, loadSample, createExampleWidgets,
+} from './src/world/animatedSample.js';
+import {
+    installTerrainPanel,
+    ensureTerrainBrushHelper, getTerrainHitFromEvent,
+    updateTerrainBrushPreview, applyTerrainBrushFromEvent,
+    serializeWorldTerrainState, applyWorldTerrainState, setupTerrainPanel,
+} from './src/editor/terrainPanel.js';
+import {
+    installActorPhysics,
+    buildCollisionBoxComponent, getActorPhysicsSettings, clearActorPhysicsPreview,
+    refreshActorPhysicsPreview, setActorPhysicsPreview, applyActorPhysicsSettings,
+    syncBlueprintPhysicsEditor, applyBlueprintPhysicsEditor, rebuildActorPhysics,
+    syncTransformControlState, syncTransformToPhysics,
+} from './src/physics/actorPhysics.js';
+import {
+    setupGameplayLoop,
+    resetMobileInputState, resetMovementInputState,
+    refreshGameplayWorld,
+    setupGameplayEvents, adjustShowcaseSpeed, updateShowcaseInput,
+    handleGameplayKeyEvent, handleGameplayMouseMove, handleShowcaseMouseButton,
+    handleShowcaseContextMenu, handleShowcaseWheel, handlePointerLockChange,
+    enterGameplay, exitGameplay, forceExitGameplayForWorldLoad, updateWorldPresentation,
+    updateMainDirectionalLightShadowFocus, updateGameplayUI,
+    getShowcaseTarget, resetShowcaseCamera, updateShowcaseCamera, respawnPlayer,
+    applyGameplayCameraRotation, resolveHorizontalMovement, updateGameplay,
+    syncGameplaySpawnToCamera, syncShowcaseAnglesFromTarget, syncShowcaseAnglesToFaceTarget,
+    applyShowcaseCameraRotation,
+} from './src/gameplay/gameplayLoop.js';
+import {
+    cloneDisposableObject,
+    formatImportedPropName,
+    normalizeObjectToDimension,
+    createLoadingManager,
+    convertLoadedObjectMaterials,
+    loadObjectFromFile,
+} from './src/io/objectLoader.js';
+import { createSocketMultiplayer } from './src/network/socketMultiplayer.js';
+import { runWebGPUBenchmark } from './webgpu_utils.js';
+import { createPhysicsCore } from './src/physics/core.js';
+import { createPhysicsRuntime } from './src/physics/runtime.js';
+import { createEnvironmentController } from './src/world/environment.js';
+import { createLightGridController } from './src/world/lightGrid.js';
+import { createVolumetricFog } from './src/world/volumetricFog.js';
+import { createPostProcessVolumeManager } from './src/world/postProcessVolume.js';
+import { getDDGIManager } from './src/world/gi/ddgiManager.js';
+import {
+    createActor,
+    createSceneSystem,
+    ensureActorScriptComponent,
+    AudioComponent,
+    getMetadataComponent,
+    getPhysicsBodyComponent,
+    getRenderComponent,
+    getScriptComponent,
+    PhysicsComponent,
+    TransformComponent,
+    DDGIVolumeComponent,
+} from './src/runtime/sceneRuntime.js';
+import {
+    TERRAIN_Y_OFFSET,
+    applyTerrainTextures,
+    createTerrainMesh,
+    sampleTerrainHeightAt as sampleTerrainHeightAtWorldFloor,
+    setTerrainModeGrid,
+    setTerrainModeSolid,
+    setTerrainModeGrassPBR,
+    setTerrainCustomImage,
+    setTerrainTint,
+    setTerrainRepeat,
+    setTerrainRoughness,
+    applyTerrainSculptBrush,
+    serializeTerrainState,
+    applySerializedTerrainState,
+} from './src/world/terrain.js';
+import { createGrassField } from './src/world/grass.js';
+import { createWater } from './src/world/water.js';
+import { createLitePhysicsPool } from './src/physics/litePool.js';
+import {
+    AHUD,
+    installUePrototypeMethods,
+    buildUeContext,
+    detectsUeLifecycle,
+    UButtonWidget,
+    UImageWidget,
+    UProgressBarWidget,
+    UTextWidget,
+    UUserWidget,
+} from './src/scripting/ueApi.js';
+import {
+    SoundGeneratorAudioListener,
+    EngineSoundGenerator as WasmEngineSoundGenerator,
+} from './vendor/engine-sound/sound_generator_worklet_wasm.js';
 
-document.querySelector('#app').innerHTML = `
-<section id="center">
-  <div class="hero">
-    <img src="${heroImg}" class="base" width="170" height="179">
-    <img src="${javascriptLogo}" class="framework" alt="JavaScript logo"/>
-    <img src=${viteLogo} class="vite" alt="Vite logo" />
-  </div>
-  <div>
-    <h1>Get started</h1>
-    <p>Edit <code>src/main.js</code> and save to test <code>HMR</code></p>
-  </div>
-  <button id="counter" type="button" class="counter"></button>
-</section>
+// === Extracted modules (root main.js was 436 KB; split to keep <256 KB) ===
+import {
+    bindAppCore,
+} from './src/runtime/appCore.js';
+import {
+    compressTextures,
+} from './src/optim/textureCompression.js';
+import {
+    setupVehicleEngineAudio,
+    setEngineAudioDebugEl,
+    playSpeakerTestTone,
+    playMediaElementTestSound,
+    resolveSoundLocation,
+    cleanupTransientAudio,
+    clampVehicleEngineRpm,
+    resetVehicleEngineAudioState,
+    createVehicleEngineWasmParameters,
+    describeVehicleEngineWasmError,
+    markVehicleEngineWasmUnavailable,
+    shutdownVehicleEngineAudioWasm,
+    primeVehicleEngineAudioWasm,
+    shutdownLegacyVehicleEngineAudio,
+    shutdownVehicleEngineAudio,
+    silenceVehicleEngineAudio,
+    ensureLegacyVehicleEngineAudio,
+    ensureVehicleEngineAudioWasm,
+    ensureVehicleEngineAudio,
+    updateLegacyVehicleEngineAudio,
+    updateVehicleEngineAudioWasm,
+    updateVehicleEngineAudio,
+    updateEngineAudioDebugOverlay,
+    resolveRuntimeSoundBuffer,
+    playSoundAtLocation,
+    getAudioTestLocation,
+    playAudioTestCue,
+} from './src/audio/vehicleEngineAudio.js';
+import {
+    setupObjectMaterial,
+    setActorColor,
+    markActorMaterialDirty,
+    getObjectMaterialArray,
+    clampMaterialStateValue,
+    serializeMaterialSide,
+    deserializeMaterialSide,
+    serializeSingleMaterialState,
+    getObjectMaterialPreviewState,
+    serializeObjectMaterialState,
+    applyObjectMaterialState,
+    serializeObjectMaterialOverrides,
+    getObjectByHierarchyPath,
+    applyObjectMaterialOverrides,
+} from './src/world/objectMaterial.js';
+import {
+    setupMouseActions,
+    readMouseActionDrafts,
+    saveMouseActionDrafts,
+    getMouseActionLabel,
+    getMouseActionMessage,
+    updateMouseActionStatus,
+    syncInputActionsEditor,
+    openInputActionsEditor,
+    closeInputActionsEditor,
+    updateSelectedMouseActionSource,
+    compileMouseActionScript,
+    buildMouseActionApi,
+    applyMouseActionScripts,
+    resetMouseActionScripts,
+    initializeMouseActionScripts,
+    runMouseAction,
+} from './src/scripting/mouseActions.js';
+import {
+    setupObjectEvents,
+    compileObjectEventScript,
+    syncPropScriptState,
+    createDynamicPropActor,
+    removeObjectScriptDraft,
+    findDynamicPropByMesh,
+    getObjectScriptEventLabel,
+    getDynamicPropDisplayName,
+    getDynamicPropById,
+    isTransformControlSphereHit,
+    getDynamicPropHitFromEvent,
+    updateObjectScriptEditorStatus,
+    syncObjectScriptEditor,
+    closeObjectScriptMenu,
+    closeObjectScriptEditor,
+    maybeOpenObjectScriptMenuFromMobileTap,
+    openObjectScriptMenu,
+    openObjectScriptEditor,
+    updatePropScriptSource,
+    clearPropScriptSource,
+    setPropTickEventEnabled,
+    buildObjectEventApi,
+    handleObjectScriptRuntimeError,
+    runObjectEventScript,
+    runObjectTickScripts,
+    getActorByBodyId,
+} from './src/scripting/objectEvents.js';
+import {
+    setupDebugConsole,
+    pushTimingSample,
+    getAverageTiming,
+    formatTimingMs,
+    renderDebugConsoleOutput,
+    pushDebugConsoleLine,
+    focusDebugConsoleInput,
+    setDebugConsoleVisible,
+    createDebugStatRow,
+    createDebugStatPanel,
+    syncDebugStatPanels,
+    updateDebugStatPanels,
+    setDebugStatPanel,
+    runStatCommand,
+    applyMobileModeState,
+    runMobileCommand,
+    runRayDebugCommand,
+    runMeshShadowsCommand,
+    debugCommandRegistry,
+    executeDebugConsoleCommand,
+    handleDebugConsoleInputKeydown,
+    handleDebugConsoleKeydown,
+    recordDebugFrameMetrics,
+} from './src/debug/console.js';
+import {
+    setupMobileControls,
+    setMobileMenuOpen,
+    setTouchThumbPosition,
+    clearMobilePad,
+    applyMobileMoveVector,
+    updateMobileMovePad,
+    resetMobileMovePad,
+    applyMobileLookDelta,
+    updateMobileLookPad,
+    resetMobileLookPad,
+    syncMobileActionVisibility,
+    updateMobileButtons,
+    applyMobileHoldButton,
+    bindMobilePad,
+} from './src/ui/mobileControls.js';
+import {
+    setupSceneSerialization,
+    loadWorldFromSceneFolder,
+    getActorComponentFlags,
+    setActorComponentFlags,
+    normalizeSerializedActorComponentFlags,
+    serializeActorData,
+    spawnActorFromSerializedData,
+    exportActorToFile,
+    progressOverlay,
+    yieldToPaint,
+    loadActorFromFile,
+    readFileAsTextWithProgress,
+    clearSceneActors,
+    loadWorldFromUmap,
+} from './src/world/sceneSerialization.js';
+import {
+    setupBlueprintEditor,
+    enterBlueprintEditor,
+    exitBlueprintEditor,
+    formatBlueprintMaterialScalar,
+    getBlueprintMaterialEditorRefs,
+    getBlueprintComponentDisplayName,
+    isBlueprintMaterialTarget,
+    getBlueprintMaterialTargets,
+    getBlueprintMaterialPreviewTarget,
+    setBlueprintMaterialScalarPair,
+    setBlueprintDetailsMode,
+    syncBlueprintLightScalarInput,
+    setBlueprintLightScalarPair,
+    readBlueprintLightScalarInput,
+    setBlueprintSpotRowsVisible,
+    syncBlueprintLightEditor,
+    setBlueprintMaterialEditorEnabled,
+    syncBlueprintMaterialEditor,
+    syncBlueprintMaterialScalarInput,
+    readBlueprintMaterialScalarInput,
+    readBlueprintMaterialEditorState,
+    applyBlueprintMaterialEdits,
+    previewBlueprintMaterialEdits,
+    readBlueprintLightEditorState,
+    applyBlueprintLightEdits,
+    refreshBlueprintComponents,
+    updateBlueprintTransformUI,
+    updateBlueprintDetailsUI,
+    applyBlueprintDetailsFromUI,
+} from './src/editor/blueprintEditor.js';
+import {
+    setupSceneHistory,
+    snapshotSceneState,
+    restoreSceneState,
+    serializeComponentTree,
+    deserializeComponentTree,
+    serializeActorToJSON,
+    spawnActorFromJSON,
+    deleteSelectedActor,
+    copySelectedToClipboard,
+    pasteFromClipboard,
+    duplicateSelected,
+    editorHistory,
+    exportWorldToJSON,
+    loadWorldFromJSON,
+} from './src/editor/sceneHistory.js';
 
-<div class="ticks"></div>
 
-<section id="next-steps">
-  <div id="docs">
-    <svg class="icon" role="presentation" aria-hidden="true"><use href="/icons.svg#documentation-icon"></use></svg>
-    <h2>Documentation</h2>
-    <p>Your questions, answered</p>
-    <ul>
-      <li>
-        <a href="https://vite.dev/" target="_blank">
-          <img class="logo" src=${viteLogo} alt="" />
-          Explore Vite
-        </a>
-      </li>
-      <li>
-        <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" target="_blank">
-          <img class="button-icon" src="${javascriptLogo}" alt="">
-          Learn more
-        </a>
-      </li>
-    </ul>
-  </div>
-  <div id="social">
-    <svg class="icon" role="presentation" aria-hidden="true"><use href="/icons.svg#social-icon"></use></svg>
-    <h2>Connect with us</h2>
-    <p>Join the Vite community</p>
-    <ul>
-      <li><a href="https://github.com/vitejs/vite" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="/icons.svg#github-icon"></use></svg>GitHub</a></li>
-      <li><a href="https://chat.vite.dev/" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="/icons.svg#discord-icon"></use></svg>Discord</a></li>
-      <li><a href="https://x.com/vite_js" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="/icons.svg#x-icon"></use></svg>X.com</a></li>
-      <li><a href="https://bsky.app/profile/vite.dev" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="/icons.svg#bluesky-icon"></use></svg>Bluesky</a></li>
-    </ul>
-  </div>
-</section>
+installUePrototypeMethods();
 
-<div class="ticks"></div>
-<section id="spacer"></section>
-`
 
-setupCounter(document.querySelector('#counter'))
+// Global widget manager instance
+let widgetManager;
+let runtimeHud;
+
+// Widget API functions (call these from Three.js commands)
+window.WidgetAPI = {
+    createWidget: (type, config) => {
+        if (!widgetManager) return null;
+        return widgetManager.createWidget(type, config);
+    },
+
+    updateWidget: (id, updates) => {
+        if (!widgetManager) return false;
+        return widgetManager.updateWidget(id, updates);
+    },
+
+    showWidget: (id, visible) => {
+        if (!widgetManager) return false;
+        return widgetManager.showWidget(id, visible);
+    },
+
+    removeWidget: (id) => {
+        if (!widgetManager) return false;
+        return widgetManager.removeWidget(id);
+    },
+
+    setWidgetPosition: (id, position, space) => {
+        if (!widgetManager) return false;
+        return widgetManager.setWidgetPosition(id, position, space);
+    },
+
+    setWidgetScale: (id, scale) => {
+        if (!widgetManager) return false;
+        return widgetManager.setWidgetScale(id, scale);
+    },
+
+    getWidget: (id) => {
+        if (!widgetManager) return null;
+        return widgetManager.getWidget(id);
+    },
+
+    getAllWidgets: () => {
+        if (!widgetManager) return [];
+        return widgetManager.getAllWidgets();
+    }
+};
+
+function getRuntimeHud() {
+    if (!runtimeHud) {
+        runtimeHud = new AHUD({ widgetApi: window.WidgetAPI });
+    }
+    return runtimeHud;
+}
+
+window.UnrealWidgetAPI = {
+    AHUD,
+    UUserWidget,
+    UTextWidget,
+    UImageWidget,
+    UProgressBarWidget,
+    UButtonWidget,
+    CreateWidget: (WidgetClass = UUserWidget, config = {}) => getRuntimeHud().CreateWidget(WidgetClass, config),
+    GetHUD: () => getRuntimeHud(),
+};
+
+// Example widget creation function
+// --- Configuration ---
+let scene, camera, renderer, currentMesh, transformControl, postProcessing, mainDirectionalLight;
+let originalTriCount = 0;
+let optimizedTriCount = 0;
+let scanPlane;
+let originalFileSize = 0;
+let optimizedBlobUrl = null;
+let environmentController, volumetricFogController, postProcessVolumeManager;
+const globalPostProcessUniforms = {
+    bloomStrength: uniform(1.25),
+    bloomRadius: uniform(0.95),
+    bloomThreshold: uniform(0.48)
+};
+
+// Performance toggle: when on, skips DDGI tick, volumetric fog update, and the
+// post-process volume update. The three subsystems own their own state via
+// setEnabled, so flipping this back to false restores the default render path
+// without a reload. Defaults to off — engine ships unchanged.
+let perfModeEnabled = false;
+let perfModeUiRefs = null;
+
+// World Environment panel state — Godot-style WorldEnvironment node mirror.
+// Each section can be toggled on/off independently, and key values are tunable
+// via sliders. State persists to localStorage so reloads keep the last config.
+// Defaults match the engine's out-of-box look — DDGI off (heavy), everything
+// else on. Changing the master "All Off" or "Performance" preset rewrites the
+// `enabled` fields but preserves slider values.
+const WORLD_ENV_STORAGE_KEY = 'polyflow.worldEnvironment.v1';
+const WORLD_ENV_DEFAULTS = Object.freeze({
+    sky: { enabled: true, preset: 'sunny-sky', blurriness: 0.05 },
+    ambient: { enabled: true, intensity: 1.0 },
+    hemi: { enabled: true, intensity: 1.5 },
+    sun: { enabled: true, castShadow: true, intensity: 2.5 },
+    tonemap: { exposure: 1.0 },
+    bloom: { enabled: true, strength: 1.25, radius: 0.95, threshold: 0.48 },
+    fog: { enabled: true, density: 0.012, opacity: 0.055 },
+    ddgi: { enabled: false, probesPerFrame: 4, intensity: 0.18 },
+    shadows: { enabled: true },
+});
+let worldEnvState = JSON.parse(JSON.stringify(WORLD_ENV_DEFAULTS));
+let worldEnvUiRefs = null;
+let physicsCore;
+let physicsRuntime;
+let multiplayerController;
+let sceneSystem;
+const animationMixers = new Map();
+const actorCoreSyncState = new Map();
+const EXPORT_MAX_TEXTURE_SIZE = 1024;
+const MODEL_TARGET_MAX_DIMENSION = 12;
+const PROP_TARGET_MAX_DIMENSION = 2.35;
+const VEHICLE_CUSTOM_IMPORT_VALUE = '__custom_import__';
+const IMPORTED_PROP_MAX_HULL_POINTS = 480;
+const IMPORTED_PROP_MAX_HULL_PARTS = 18;
+const IMPORTED_PROP_COMPLEX_HULL_RADIUS = 0.01;
+const SHOWCASE_CAMERA_POSITION = new THREE.Vector3(6.5, 4.2, 8.5);
+const SHOWCASE_CAMERA_TARGET = new THREE.Vector3(0, 1.4, 0);
+const JOLT_NON_MOVING_LAYER = 0;
+const JOLT_MOVING_LAYER = 1;
+const JOLT_OBJECT_LAYER_COUNT = 2;
+const JOLT_BROAD_PHASE_LAYER_COUNT = 2;
+const PLAYER_SETTINGS = {
+    eyeHeight: 1.7,
+    walkSpeed: 4.5,
+    sprintSpeed: 7.2,
+    jumpSpeed: 6.8,
+    gravity: 18,
+    collisionRadius: 0.6,
+    wallClearance: 0.12,
+    probeHeight: 80,
+    maxLookPitch: Math.PI / 2 - 0.08,
+    floorOffset: 0.04,
+};
+const VEHICLE_SETTINGS = {
+    length: 2.6,
+    width: 1.35,
+    height: 0.6,
+    mass: 1200,
+    wheelBase: 1.72,
+    trackWidth: 1.18,
+    spawnDistance: 4.8,
+    spawnLift: 0.02,
+    interactionRadius: 4.5,
+    seatHeight: 1.15,
+    followDistance: 5.6,
+    followHeight: 2.4,
+    lookAhead: 2.2,
+    cameraHorizontalSmoothing: 8.0,
+    cameraVerticalSmoothing: 2.2,
+    cameraLookSmoothing: 5.0,
+    acceleration: 3.0,
+    reverseAcceleration: 2.0,
+    boostAcceleration: 4.5,
+    coastDrag: 0.8,
+    rollingDrag: 0.05,
+    lowSpeedGrip: 8.0,
+    highSpeedGrip: 5.5,
+    brakeGrip: 10.0,
+    driftGrip: 2.0,
+    partialContactGrip: 1.5,
+    driftBoostThreshold: 0.4,
+    driftSteerBonus: 1.2,
+    steeringRate: 2.8,
+    steeringReturn: 5.0,
+    steeringGrip: 6.0,
+    steeringHighSpeedDamping: 0.35,
+    uprightTorque: 40,
+    rollTorque: 15,
+    pitchTorque: 10,
+    suspensionRideHeight: 0.43,
+    suspensionTravel: 0.25,
+    suspensionSpring: 2.8,
+    suspensionDamping: 12.0,
+    bumpPitchTorque: 0,
+    bumpRollTorque: 0,
+    bumpLaunchBoost: 0,
+    airtimeAngularBlend: 0.03,
+    maxDriveSpeed: 28,
+    maxReverseSpeed: 8,
+    brakeDamping: 0.85,
+    maxAngularVelocity: 3.0,
+};
+const PHYSICS_COLLISION_STEPS = 2;
+const TEST_SOUND_ID = 'polyflow:test';
+
+// Module-level refs so switchEnvironment can update them
+let pedestalMat, ambientLight, hemiLight, pedestal, worldFloor;
+let grassField = null;
+let water = null;
+const litePools = [];
+let playHint, gameplayStatus, resetViewBtn, showcaseModeBtn, playModeBtn, browseModelBtn, openActorEditorBtn;
+let playTestSoundBtn, playTestSoundStatus;
+let multiplayerServerUrlInput, multiplayerRoomInput, multiplayerConnectBtn, multiplayerDisconnectBtn, multiplayerStatusValue, multiplayerPlayerCountValue;
+let importPropBtn, propFileInput, importedPropList, importedPropLibrary, propImportDefaultStatus, resetPropImportDefaultBtn;
+let postProcessUiRefs;
+let shadowDebugUiRefs;
+let propCollisionPrompt, propCollisionCopy, propCollisionRemember, propCollisionSimpleBtn, propCollisionComplexBtn, propCollisionCancelBtn;
+let inputActionsOpenBtn, inputActionsEditor, inputActionLeftBtn, inputActionRightBtn, inputActionMode, inputActionEditorInput, inputActionsEditorStatus, mouseActionApplyBtn, mouseActionResetBtn, inputActionsCloseBtn, mouseActionStatus;
+let objectScriptMenu, objectScriptTickActionBtn, objectScriptCollisionActionBtn;
+let objectScriptEditor, objectScriptEditorTitle, objectScriptEditorTarget, objectScriptEditorMode;
+let objectScriptEditorInput, objectScriptEditorStatus, objectScriptEditorApplyBtn, objectScriptEditorClearBtn, objectScriptEditorCancelBtn;
+let objectScriptTickToggleRow, objectScriptTickToggleInput;
+let actorEditor, actorEditorSummary, actorEditorStatus, actorKindSelect, actorLabelInput, actorScaleInput, actorImportedTemplateSelect, actorVehicleBodyTemplateSelect, actorVehicleWheelTemplateSelect, vehicleTemplateImportInput;
+// Tracks which vehicle slot ('body'|'wheel') triggered the file picker so the
+// import handler knows which select to update.
+let pendingVehicleTemplateImportSlot = null;
+let actorComponentCollisionInput, actorComponentPhysicsInput, actorComponentScriptsInput, actorEditorCreateBtn, actorEditorOpenScriptBtn, actorEditorCancelBtn;
+let debugConsole, debugConsoleOutput, debugConsoleInput, debugConsoleFooter, debugStatsOverlay, engineAudioDebugEl;
+let sceneUiPanel, sceneUiCount, sceneUiList;
+let mobileMenuToggleBtn, mobileModeToggleBtn;
+let mobileMovePad, mobileMoveThumb, mobileLookPad, mobileLookThumb;
+let mobileJumpBtn, mobileRightActionBtn, mobileAction2Btn;
+let lightGridController;
+const IMPORTED_PROP_COLLISION_LABELS = {
+    simple: 'simple box collision',
+    complex: 'tighter convex collision',
+};
+const MOBILE_MOVE_THRESHOLD = 0.18;
+const MOBILE_MOVE_RADIUS_FACTOR = 0.36;
+const MOBILE_LOOK_SENSITIVITY = 0.0045;
+const mobileState = {
+    enabled: false,
+    detected: false,
+    forced: false,
+    menuOpen: false,
+    movePointerId: null,
+    lookPointerId: null,
+    lastWorldTapTime: 0,
+    lastWorldTapX: 0,
+    lastWorldTapY: 0,
+};
+const importedPropState = {
+    nextId: 1,
+    templates: [],
+    futureCollisionMode: null,
+    promptResolver: null,
+    // Track the original imported File per template so "Save Scene Folder"
+    // can copy the raw asset alongside the .umap rather than inlining the
+    // mesh as a giant rootJson blob (which is what makes legacy .umap loads
+    // slow). Keyed by template.id.
+    sourceFiles: Object.create(null),
+};
+const actorEditorState = {
+    open: false,
+};
+const blueprintState = {
+    active: false,
+    targetActor: null,
+    selectedComponent: null,
+    selectedComponents: new Set(),
+    materialMultiSelectActive: false,
+    floorMesh: null,
+    savedCameraPosition: null,
+    savedShowcaseAngles: null,
+    savedBackground: null
+};
+const postProcessUiState = {
+    target: 'global',
+};
+const MOUSE_ACTION_STORAGE_KEY = 'polyflow-3d.mouse-actions.v1';
+const OBJECT_SCRIPT_STORAGE_KEY = 'polyflow-3d.object-scripts.v1';
+const DEBUG_CONSOLE_LOG_LIMIT = 18;
+const DEBUG_CONSOLE_HISTORY_LIMIT = 24;
+const DEBUG_TIMING_SAMPLE_LIMIT = 30;
+const DEFAULT_MOUSE_ACTION_SCRIPTS = {
+    left: `const direction = Character?.GetActorForwardVector?.()?.GetSafeNormal?.() ?? FVector.Forward();
+const playerLocation = Character?.GetActorLocation?.() ?? FVector.Zero();
+const spawnLocation = playerLocation
+    .Add(direction.Scale(1.8))
+    .Add(new FVector(0, 1.35, 0));
+
+const sphere = World.SpawnActor('Sphere', spawnLocation);
+const phys = sphere?.GetComponentByClass(UPrimitiveComponent);
+
+if (phys) {
+    phys.AddImpulse(direction.Scale(36000));
+}`,
+    right: `spawnLiteCubeStorm({ count: 100, halfExtent: 0.2, spacing: 0.55 })
+`,
+};
+const MouseActionFunction = Object.getPrototypeOf(async function () {}).constructor;
+const ObjectEventFunction = MouseActionFunction;
+const mouseActionState = {
+    leftSource: DEFAULT_MOUSE_ACTION_SCRIPTS.left,
+    rightSource: DEFAULT_MOUSE_ACTION_SCRIPTS.right,
+    leftCompiled: null,
+    rightCompiled: null,
+    leftError: '',
+    rightError: '',
+    selectedButton: 'left',
+};
+const objectScriptState = {
+    nextPropId: 1,
+    drafts: {},
+    menuOpen: false,
+    editorOpen: false,
+    menuScreenX: 0,
+    menuScreenY: 0,
+    targetPropId: '',
+    targetObjectUuid: '',
+    targetEvent: 'tick',
+};
+const debugConsoleState = {
+    visible: false,
+    lines: [
+        { prefix: 'sys', text: 'Console ready. Try `stat unit`, `stat physics`, or `stat gpu`.', tone: 'success' },
+    ],
+    history: [],
+    historyIndex: -1,
+    panels: new Set(),
+    panelRefs: new Map(),
+    latest: {
+        frame: 0,
+        update: 0,
+        physics: 0,
+        physicsStep: 0,
+        physicsSync: 0,
+        physicsCollisions: 0,
+        scripts: 0,
+        render: 0,
+        fps: 0,
+        delta: 0,
+        collisionSteps: 0,
+    },
+    samples: {
+        frame: [],
+        update: [],
+        physics: [],
+        physicsStep: [],
+        physicsSync: [],
+        physicsCollisions: [],
+        scripts: [],
+        render: [],
+    },
+    gpuTimingMode: 'approximate',
+};
+const multiplayerState = {
+    defaultRoom: 'sandbox',
+};
+
+const clock = new THREE.Clock();
+const downVector = new THREE.Vector3(0, -1, 0);
+const upVector = new THREE.Vector3(0, 1, 0);
+const gameplayBounds = new THREE.Box3();
+const gameplayLookTarget = new THREE.Vector3(0, 1, 0);
+const raycaster = new THREE.Raycaster();
+const pointerNdc = new THREE.Vector2();
+const tempVectorA = new THREE.Vector3();
+const tempVectorB = new THREE.Vector3();
+const tempVectorC = new THREE.Vector3();
+const tempVectorD = new THREE.Vector3();
+const tempVectorE = new THREE.Vector3();
+const mainDirectionalLightOffset = new THREE.Vector3(5, 10, 5);
+const mainDirectionalLightShadowFocus = new THREE.Vector3();
+const tempBoxA = new THREE.Box3();
+const tempQuaternionA = new THREE.Quaternion();
+const tempQuaternionB = new THREE.Quaternion();
+const raycastDebugState = {
+    enabled: false,
+    helper: null,
+    hitMarker: null,
+    points: [new THREE.Vector3(), new THREE.Vector3()],
+    expiresAt: 0,
+    lastConsoleHitKey: '',
+    timeoutMs: Number.POSITIVE_INFINITY,
+};
+const collisionDebugState = {
+    enabled: false,
+    overlays: [],
+};
+const actorPhysicsEditorState = {
+    previewActorId: '',
+    previewOverlay: null,
+};
+const shadowDebugState = {
+    forceAllMeshes: false,
+    lastAppliedAt: 0,
+    lastMeshCount: 0,
+    lastUpdatedCount: 0,
+    lastLightCount: 0,
+    autoApplyIntervalMs: 500,
+};
+const gameplay = {
+    canPlay: true,
+    active: false,
+    pointerLocked: false,
+    grounded: false,
+    yaw: 0,
+    pitch: -0.1,
+    spawnYaw: 0,
+    spawnPitch: -0.1,
+    velocity: new THREE.Vector3(),
+    spawnPoint: new THREE.Vector3(0, PLAYER_SETTINGS.eyeHeight + 0.2, 6),
+    input: {
+        forward: false,
+        back: false,
+        left: false,
+        right: false,
+        sprint: false,
+    },
+};
+const vehicleState = {
+    activePropId: '',
+    brakeHeld: false,
+    tailWhipLastFrame: false,
+};
+const vehicleFx = createVehicleFx({
+    getScene: () => scene,
+    vehicleSettings: VEHICLE_SETTINGS,
+});
+const emitVehicleParticle = vehicleFx.emitParticle;
+const emitVehicleSurfaceEffects = vehicleFx.emitSurfaceEffects;
+const updateVehicleSurfaceEffects = vehicleFx.updateSurfaceEffects;
+const vehicleEngineAudio = {
+    activePropId: '',
+    backend: 'none',
+    listener: null,
+    wasmGenerator: null,
+    wasmLoadPromise: null,
+    wasmModuleReady: false,
+    wasmFailed: false,
+    wasmFailureReason: '',
+    wasmThrottleParam: null,
+    wasmRpmParam: null,
+    combustionNode: null,
+    harmonic2Node: null,
+    harmonic3Node: null,
+    bodyNode: null,
+    subNode: null,
+    whineNode: null,
+    noiseNode: null,
+    crackleNode: null,
+    idleLfo: null,
+    combustionGain: null,
+    harmonic2Gain: null,
+    harmonic3Gain: null,
+    bodyGain: null,
+    subGain: null,
+    whineGain: null,
+    intakeGain: null,
+    overrunGain: null,
+    crackleGain: null,
+    crackleEnvelope: null,
+    idleLfoGain: null,
+    idleLfoOffset: null,
+    outputGain: null,
+    compressor: null,
+    waveShaper: null,
+    exhaustFilter: null,
+    resonancePeak: null,
+    resonanceFilter: null,
+    intakeFilter: null,
+    hissFilter: null,
+    cabinFilter: null,
+    masterTone: null,
+    panner: null,
+    idleRpm: 540,
+    minRpm: 480,
+    maxRpm: 4200,
+    rpm: 540,
+    targetRpm: 540,
+    gear: 1,
+    throttle: 0,
+    lastThrottle: 0,
+    overrun: 0,
+    lastGrounded: false,
+    crackleCooldown: 0,
+    lastWorldPosition: new THREE.Vector3(),
+    velocity: new THREE.Vector3(),
+};
+const showcase = {
+    looking: false,
+    yaw: 0,
+    pitch: -0.1,
+    moveSpeed: 9,
+    minMoveSpeed: 2,
+    maxMoveSpeed: 48,
+    wheelSpeedStep: 1.18,
+    boostMultiplier: 2.4,
+    velocity: new THREE.Vector3(),
+    input: {
+        forward: false,
+        back: false,
+        left: false,
+        right: false,
+        up: false,
+        down: false,
+        boost: false,
+    },
+};
+const terrainBrushState = {
+    enabled: false,
+    active: false,
+    tool: 'raise',
+    radius: 5,
+    strength: 0.18,
+    flattenHeight: 0,
+    paintColor: '#5f8f35',
+    foliageDensity: 80,
+    foliageType: 'grass',
+    helper: null,
+    helperScale: 1,
+    dirtyPhysics: false,
+};
+const physics = {
+    ready: false,
+    failed: false,
+    Jolt: null,
+    jolt: null,
+    physicsSystem: null,
+    bodyInterface: null,
+    gravity: null,
+    movingBroadPhaseFilter: null,
+    movingLayerFilter: null,
+    bodyFilter: null,
+    shapeFilter: null,
+    updateSettings: null,
+    characterShape: null,
+    character: null,
+    characterListener: null,
+    terrainBody: null,
+    modelBody: null,
+    dynamicBodies: [],
+    staticBodies: [],
+    desiredVelocity: new THREE.Vector3(),
+    jumpQueued: false,
+    allowSliding: false,
+};
+const runtimeAudio = {
+    listener: null,
+    loader: new THREE.AudioLoader(),
+    unlocked: false,
+    testBuffer: null,
+    mediaTestUrl: null,
+    transientAnchors: new Set(),
+    resume() {
+        const context = this.listener?.context ?? null;
+        if (!context || context.state === 'running') {
+            this.unlocked = !!context;
+            return Promise.resolve();
+        }
+
+        return context.resume()
+            .then(() => {
+                this.unlocked = true;
+            })
+            .catch((error) => {
+                console.warn('Failed to resume audio context.', error);
+            });
+    },
+};
+
+
+// === extracted: vehicleEngineAudio (functions) (was lines 673-1766 of original main.js) ===
+
+physicsCore = createPhysicsCore({
+    physics,
+    playerSettings: PLAYER_SETTINGS,
+    objectLayerCount: JOLT_OBJECT_LAYER_COUNT,
+    broadPhaseLayerCount: JOLT_BROAD_PHASE_LAYER_COUNT,
+    nonMovingLayer: JOLT_NON_MOVING_LAYER,
+    movingLayer: JOLT_MOVING_LAYER,
+    getTerrainRoot: () => worldFloor,
+    getModelRoot: () => currentMesh,
+    onCharacterRefresh: () => ensurePlayerCharacter(),
+});
+physicsRuntime = createPhysicsRuntime({
+    physics,
+    gameplay,
+    playerSettings: PLAYER_SETTINGS,
+    collisionSteps: PHYSICS_COLLISION_STEPS,
+    getCamera: () => camera,
+    getWorldFloor: () => worldFloor,
+    copyJoltVector,
+    copyJoltQuaternion,
+    createOwnedShape: (settings) => createOwnedShape(settings),
+    onRemoveDynamicProp: (prop, index) => {
+        destroyDynamicPhysicsProp(prop);
+        physics.dynamicBodies.splice(index, 1);
+    },
+    onCollisionScriptsUpdate: () => updateDynamicBodyCollisionScripts(),
+    onCollisionStepsChange: (collisionSteps) => {
+        debugConsoleState.latest.collisionSteps = collisionSteps;
+    },
+});
+
+function switchEnvironment(key) {
+    environmentController?.switchEnvironment(key);
+}
+
+function setResolution(res) {
+    environmentController?.setResolution(res);
+}
+
+function sampleTerrainHeightAt(worldX, worldZ) {
+    return sampleTerrainHeightAtWorldFloor(worldFloor, worldX, worldZ);
+}
+
+function buildLightGrid() {
+    //lightGridController?.build();
+}
+
+function getLightGridAnchorTarget() {
+    if (currentMesh) {
+        return tempVectorD.copy(gameplayLookTarget);
+    }
+
+    return tempVectorD.copy(SHOWCASE_CAMERA_TARGET);
+}
+
+function positionLightGrid(anchorTarget) {
+    lightGridController?.position(anchorTarget);
+}
+
+function handleLightGridClick(event) {
+    if (isTransformControlSphereHit(event)) {
+        return;
+    }
+
+    lightGridController?.handleClick(event);
+}
+
+function serializeVector3(vector) {
+    return { x: vector.x, y: vector.y, z: vector.z };
+}
+
+function serializeQuaternion(quaternion) {
+    return { x: quaternion.x, y: quaternion.y, z: quaternion.z, w: quaternion.w };
+}
+
+function getDefaultMultiplayerServerUrl() {
+    const isLocalHost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+    return isLocalHost ? `${window.location.protocol}//${window.location.hostname}:3001` : '';
+}
+
+function updateMultiplayerUiState({ statusText, playerCount, connected }) {
+    if (multiplayerStatusValue) {
+        multiplayerStatusValue.textContent = statusText || 'Offline';
+    }
+
+    if (multiplayerPlayerCountValue) {
+        multiplayerPlayerCountValue.textContent = `${playerCount || 1} ${playerCount === 1 ? 'player' : 'players'}`;
+    }
+
+    if (multiplayerConnectBtn) {
+        multiplayerConnectBtn.disabled = !!connected;
+    }
+
+    if (multiplayerDisconnectBtn) {
+        multiplayerDisconnectBtn.disabled = !connected;
+    }
+}
+
+function getLocalMultiplayerSnapshot() {
+    if (!camera) return null;
+
+    let localPosition;
+    let yaw;
+
+    if (gameplay.active && physics.character) {
+        localPosition = copyJoltVector(tempVectorA, physics.character.GetPosition()).clone();
+        yaw = gameplay.yaw;
+    } else {
+        localPosition = tempVectorA.copy(camera.position).clone();
+        localPosition.y -= 1.05;
+        yaw = showcase.yaw;
+    }
+
+    const localRotation = tempQuaternionB.setFromEuler(new THREE.Euler(0, yaw, 0, 'YXZ')).clone();
+    let vehicleStateSnapshot = { active: false };
+
+    if (gameplay.active && isDrivingVehicle()) {
+        const vehicle = getActiveVehicleProp();
+        if (vehicle?.body && physics.bodyInterface) {
+            const bodyId = vehicle.body.GetID();
+            const vehiclePosition = copyJoltVector(tempVectorA, physics.bodyInterface.GetPosition(bodyId)).clone();
+            const vehicleRotation = copyJoltQuaternion(tempQuaternionA, physics.bodyInterface.GetRotation(bodyId)).clone();
+            vehicleStateSnapshot = {
+                active: true,
+                id: vehicle.id || '',
+                position: serializeVector3(vehiclePosition),
+                quaternion: serializeQuaternion(vehicleRotation),
+            };
+        }
+    }
+
+    return {
+        mode: vehicleStateSnapshot.active ? 'vehicle' : gameplay.active ? 'player' : 'showcase',
+        position: serializeVector3(localPosition),
+        quaternion: serializeQuaternion(localRotation),
+        vehicle: vehicleStateSnapshot,
+    };
+}
+
+function copyJoltVector(target, source) {
+    target.set(source.GetX(), source.GetY(), source.GetZ());
+    return target;
+}
+
+function copyJoltQuaternion(target, source) {
+    target.set(source.GetX(), source.GetY(), source.GetZ(), source.GetW());
+    return target;
+}
+
+function createOwnedShape(settings) {
+    return physicsCore?.createOwnedShape(settings) ?? null;
+}
+
+function getObjectAnimationClips(root) {
+    if (!root) return [];
+
+    const clips = [];
+    const seen = new Set();
+    const addClip = (clip) => {
+        if (!clip || seen.has(clip.uuid || clip.name)) return;
+        seen.add(clip.uuid || clip.name);
+        clips.push(clip);
+    };
+
+    root.animations?.forEach(addClip);
+    root.traverse?.((child) => child.animations?.forEach(addClip));
+    return clips;
+}
+
+function stopObjectAnimations(root) {
+    const entry = animationMixers.get(root);
+    if (!entry) return;
+
+    entry.mixer.stopAllAction();
+    entry.mixer.uncacheRoot(root);
+    animationMixers.delete(root);
+}
+
+function playObjectAnimation(root, clipName = '') {
+    const clips = getObjectAnimationClips(root);
+    if (!clips.length) return null;
+
+    stopObjectAnimations(root);
+
+    const clip = clipName
+        ? THREE.AnimationClip.findByName(clips, clipName) || clips[0]
+        : clips[0];
+    const mixer = new THREE.AnimationMixer(root);
+    const action = mixer.clipAction(clip);
+    action.reset();
+    action.setLoop(THREE.LoopRepeat, Infinity);
+    action.clampWhenFinished = false;
+    action.enabled = true;
+    action.play();
+
+    root.userData.animation = {
+        ...(root.userData.animation || {}),
+        activeClip: clip.name || '',
+        clipNames: clips.map((entry) => entry.name || 'Animation'),
+        playing: true,
+    };
+    animationMixers.set(root, { mixer, action, clips });
+    return action;
+}
+
+function updateObjectAnimations(delta) {
+    animationMixers.forEach((entry) => entry.mixer.update(delta));
+}
+
+function disposeRenderableObject(root) {
+    if (!root) return;
+
+    stopObjectAnimations(root);
+
+    root.traverse((child) => {
+        if (!child.isMesh) return;
+
+        child.geometry?.dispose();
+
+        if (Array.isArray(child.material)) {
+            child.material.forEach((material) => material?.dispose());
+        } else {
+            child.material?.dispose();
+        }
+    });
+}
+
+
+async function initPhysics() {
+    return physicsCore?.initPhysics();
+}
+
+function countTrianglesForObject(root) {
+    return physicsCore?.countTrianglesForObject(root) ?? 0;
+}
+
+function createStaticMeshBody(root, options = {}) {
+    return physicsCore?.createStaticMeshBody(root, options) ?? null;
+}
+
+function destroyPhysicsBody(body) {
+    physicsCore?.destroyPhysicsBody(body);
+}
+
+function destroyDynamicPhysicsProp(prop) {
+    if (!prop) return;
+
+    if (prop.id && vehicleEngineAudio.activePropId === prop.id) {
+        shutdownVehicleEngineAudio();
+    }
+
+    if (vehicleState.activePropId && vehicleState.activePropId === prop.id) {
+        vehicleState.activePropId = '';
+        vehicleState.brakeHeld = false;
+    }
+
+    if (objectScriptState.targetPropId && objectScriptState.targetPropId === prop.id) {
+        objectScriptState.targetPropId = '';
+        transformControl?.detach();
+        objectScriptState.menuOpen = false;
+        objectScriptState.editorOpen = false;
+    }
+
+    prop.destroyAllComponents?.();
+
+    sceneSystem?.removeActor(prop);
+
+    const mesh = getActorRenderObject(prop);
+    if (mesh) {
+        disposeRenderableObject(mesh);
+
+        prop.mesh = null;
+    }
+
+    const body = getActorBody(prop);
+    if (body) {
+        physicsCore?.unregisterBackFaceCulledBody?.(body);
+        destroyPhysicsBody(body);
+        prop.body = null;
+    }
+
+    removeObjectScriptDraft(prop.id);
+}
+
+function clearDynamicPhysicsProps() {
+    if (!physics.dynamicBodies.length && !physics.staticBodies.length) return;
+
+    physics.dynamicBodies.forEach((prop) => destroyDynamicPhysicsProp(prop));
+    physics.staticBodies.forEach((prop) => destroyDynamicPhysicsProp(prop));
+    physics.dynamicBodies.length = 0;
+    physics.staticBodies.length = 0;
+}
+
+function hasEnabledDynamicPropEvent(eventType) {
+    for (let index = 0; index < physics.dynamicBodies.length; index++) {
+        const eventState = getActorScriptState(physics.dynamicBodies[index])?.[eventType];
+        if (eventState?.enabled) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function getDynamicPropSpawn(positionTarget, impulseTarget) {
+    const spawnOrigin = gameplay.active && physics.character
+        ? copyJoltVector(tempVectorC, physics.character.GetPosition()).addScaledVector(upVector, PLAYER_SETTINGS.eyeHeight * 0.55)
+        : tempVectorC.copy(camera.position);
+
+    camera.getWorldDirection(tempVectorA);
+    if (Math.abs(tempVectorA.y) > 0.72) {
+        tempVectorA.y *= 0.35;
+    }
+
+    if (tempVectorA.lengthSq() < 1e-6) {
+        tempVectorA.set(0, 0, -1);
+    } else {
+        tempVectorA.normalize();
+    }
+
+    positionTarget
+        .copy(spawnOrigin)
+        .addScaledVector(tempVectorA, gameplay.active ? 2.5 : 4.2)
+        .addScaledVector(upVector, gameplay.active ? 1.5 : 2.2);
+
+    impulseTarget
+        .copy(tempVectorA)
+        .multiplyScalar(18)
+        .addScaledVector(upVector, 5.5);
+}
+
+function spawnDrivableCar(options = {}) {
+    if (!physics.ready || !scene || !camera) {
+        console.warn('Jolt physics is not ready yet.');
+        return null;
+    }
+
+    const { Jolt, bodyInterface } = physics;
+    const spawnPosition = tempVectorD;
+    const launchImpulse = tempVectorE;
+    getDynamicPropSpawn(spawnPosition, launchImpulse);
+
+    const groundHit = getGroundHitAt(spawnPosition.x, spawnPosition.z, true, { cullBackFaces: true });
+    if (groundHit?.point) {
+        spawnPosition.y = groundHit.point.y + VEHICLE_SETTINGS.height * 0.1 + VEHICLE_SETTINGS.spawnLift;
+    }
+
+    camera.getWorldDirection(tempVectorA);
+    tempVectorA.y = 0;
+    if (tempVectorA.lengthSq() < 1e-6) {
+        tempVectorA.set(0, 0, -1);
+    } else {
+        tempVectorA.normalize();
+    }
+
+    const carRotation = tempQuaternionA.setFromUnitVectors(upVector.clone().set(0, 0, -1), tempVectorA);
+    const halfExtent = new Jolt.Vec3(
+        VEHICLE_SETTINGS.width * 0.5,
+        VEHICLE_SETTINGS.height * 0.5,
+        VEHICLE_SETTINGS.length * 0.5
+    );
+    const shape = createOwnedShape(new Jolt.BoxShapeSettings(halfExtent, 0.05));
+    Jolt.destroy(halfExtent);
+
+    const body = createDynamicPrimitiveBody(shape, spawnPosition, launchImpulse, {
+        rotation: carRotation,
+        friction: 0.8,
+        restitution: 0.05,
+        linearDamping: 0.12,
+        angularDamping: 0.3,
+        motionQuality: Jolt.EMotionQuality_LinearCast,
+        skipImpulse: true,
+        enhancedInternalEdgeRemoval: true,
+    });
+
+    if (!body) {
+        return null;
+    }
+
+    bodyInterface.SetMaxAngularVelocity(body.GetID(), VEHICLE_SETTINGS.maxAngularVelocity);
+    const bodyTemplateId = options.bodyTemplateId || '';
+    const wheelTemplateId = options.wheelTemplateId || '';
+    const chassis = createDrivableCarVisual({
+        bodyTemplateId,
+        wheelTemplateId,
+        vehicleSettings: VEHICLE_SETTINGS,
+        importedPropState,
+        cloneDisposableObject,
+    });
+    chassis.position.copy(spawnPosition);
+    chassis.quaternion.copy(carRotation);
+
+    const vehicle = createDynamicPropActor({
+        body,
+        mesh: chassis,
+        kind: 'vehicle',
+        userData: options.userData ?? { label: 'Car' },
+        includeScripts: options.includeScripts !== false,
+    });
+    vehicle.vehicleBodyTemplateId = bodyTemplateId || null;
+    vehicle.vehicleWheelTemplateId = wheelTemplateId || null;
+    setActorComponentFlags(vehicle, {
+        collision: true,
+        physics: true,
+        scripts: options.includeScripts !== false,
+    });
+    physics.dynamicBodies.push(vehicle);
+    physicsCore?.registerBackFaceCulledBody?.(body);
+    updateGameplayUI();
+    return vehicle;
+}
+
+function createDynamicPrimitiveBody(shape, position, impulse, options = {}) {
+    if (!physics.ready) return null;
+
+    const { Jolt, bodyInterface } = physics;
+    const simulatePhysics = options.simulatePhysics !== false;
+    const bodyPosition = new Jolt.RVec3(position.x, position.y, position.z);
+    const rotation = options.rotation;
+    const bodyRotation = new Jolt.Quat(
+        rotation?.x ?? 0,
+        rotation?.y ?? 0,
+        rotation?.z ?? 0,
+        rotation?.w ?? 1
+    );
+    const creationSettings = new Jolt.BodyCreationSettings(
+        shape,
+        bodyPosition,
+        bodyRotation,
+        simulatePhysics ? Jolt.EMotionType_Dynamic : Jolt.EMotionType_Static,
+        simulatePhysics ? JOLT_MOVING_LAYER : JOLT_NON_MOVING_LAYER
+    );
+    creationSettings.mFriction = options.friction ?? 0.68;
+    creationSettings.mRestitution = options.restitution ?? 0.16;
+    creationSettings.mAllowSleeping = options.allowSleeping ?? true;
+    creationSettings.mLinearDamping = options.linearDamping ?? 0.08;
+    creationSettings.mAngularDamping = options.angularDamping ?? 0.1;
+    creationSettings.mMotionQuality = options.motionQuality
+        ?? Jolt.EMotionQuality_Discrete;
+
+    if (options.allowedDOFs !== undefined) {
+        creationSettings.mAllowedDOFs = options.allowedDOFs;
+    }
+
+    // Enhanced internal edge removal eliminates ghost collisions where a body
+    // crosses a seam between coplanar triangles in a static MeshShape and the
+    // contact normal flips into the edge — the symptom is a vehicle hitting an
+    // invisible wall and flipping at track segment joints.
+    if (options.enhancedInternalEdgeRemoval === true) {
+        creationSettings.mEnhancedInternalEdgeRemoval = true;
+    }
+
+    const body = bodyInterface.CreateBody(creationSettings);
+    const mass = Number(options.mass);
+    if (simulatePhysics && Number.isFinite(mass) && mass > 0) {
+        body.GetMotionProperties?.()?.ScaleToMass?.(mass);
+    }
+    bodyInterface.AddBody(
+        body.GetID(),
+        !simulatePhysics || options.activate === false ? Jolt.EActivation_DontActivate : Jolt.EActivation_Activate
+    );
+
+    if (simulatePhysics && impulse && options.skipImpulse !== true) {
+        const launchImpulse = new Jolt.Vec3(impulse.x, impulse.y, impulse.z);
+        bodyInterface.AddImpulse(body.GetID(), launchImpulse);
+        Jolt.destroy(launchImpulse);
+    }
+
+    shape.Release();
+    Jolt.destroy(creationSettings);
+    Jolt.destroy(bodyPosition);
+    Jolt.destroy(bodyRotation);
+
+    return body;
+}
+
+function spawnDynamicPrimitive(kind, offset, scale, options = {}) {
+    if (!physics.ready || !scene || !camera) {
+        console.warn('Jolt physics is not ready yet.');
+        return;
+    }
+
+    const defaultScale = kind === 'sphere' ? 0.5 : 0.3;
+    const normalizedScale = Number.isFinite(scale) && scale > 0 ? scale : defaultScale;
+
+    const { Jolt } = physics;
+    const spawnPosition = tempVectorD;
+    const launchImpulse = tempVectorE;
+    getDynamicPropSpawn(spawnPosition, launchImpulse);
+    const impulseScale = Number.isFinite(options.impulseScale) ? options.impulseScale : 1;
+    const includeCollisionBody = options.includeCollisionBody !== false;
+    const simulatePhysics = includeCollisionBody && options.simulatePhysics !== false;
+    const useLocalPosition = options.local !== false;
+
+    if (offset) {
+        if (useLocalPosition) {
+            spawnPosition.add(tempVectorA.copy(offset).applyQuaternion(camera.quaternion));
+        } else {
+            spawnPosition.copy(offset);
+        }
+    }
+
+    if (options.skipImpulse === true) {
+        launchImpulse.set(0, 0, 0);
+    } else if (impulseScale !== 1) {
+        launchImpulse.multiplyScalar(impulseScale);
+    }
+
+    let mesh;
+    let shape;
+    let bodyOptions;
+
+    if (kind === 'sphere') {
+        const radius = normalizedScale;
+        shape = includeCollisionBody ? createOwnedShape(new Jolt.SphereShapeSettings(radius)) : null;
+        mesh = buildPrimitiveActorMesh('sphere');
+        mesh.scale.set(radius, radius, radius);
+        bodyOptions = {
+            restitution: 0.48,
+            friction: 0.58,
+            ...options,
+        };
+    } else if (kind === 'cube') {
+        const halfExtent = normalizedScale;
+        if (includeCollisionBody) {
+            const halfExtentVector = new Jolt.Vec3(halfExtent, halfExtent, halfExtent);
+            shape = createOwnedShape(new Jolt.BoxShapeSettings(halfExtentVector, 0.05));
+            Jolt.destroy(halfExtentVector);
+        }
+        mesh = buildPrimitiveActorMesh('cube');
+        mesh.scale.set(halfExtent, halfExtent, halfExtent);
+        bodyOptions = {
+            restitution: 0.12,
+            friction: 0.82,
+            ...options,
+        };
+    } else if (kind === 'capsule') {
+        const halfExtent = normalizedScale;
+        if (includeCollisionBody) {
+            shape = createOwnedShape(new Jolt.CapsuleShapeSettings(halfExtent, halfExtent));
+        }
+        mesh = buildPrimitiveActorMesh('capsule');
+        mesh.scale.set(halfExtent, halfExtent, halfExtent);
+        bodyOptions = {
+            restitution: 0.0,
+            friction: 0.0,
+            allowedDOFs: Jolt.EAllowedDOFs_TranslationX | Jolt.EAllowedDOFs_TranslationY | Jolt.EAllowedDOFs_TranslationZ,
+            ...options,
+        };
+    }
+
+    const body = includeCollisionBody
+        ? createDynamicPrimitiveBody(shape, spawnPosition, launchImpulse, {
+            ...bodyOptions,
+            simulatePhysics,
+        })
+        : null;
+
+    if (includeCollisionBody && !body) {
+        mesh.geometry.dispose();
+        mesh.material.dispose();
+        return null;
+    }
+
+    mesh.castShadow = options.castShadow ?? true;
+    mesh.receiveShadow = options.receiveShadow ?? true;
+    mesh.position.copy(spawnPosition);
+
+    const actor = createDynamicPropActor({
+        body,
+        mesh,
+        kind,
+        userData: options.userData,
+        includeScripts: options.includeScripts !== false,
+    });
+    setActorComponentFlags(actor, {
+        collision: !!body,
+        physics: !!body && simulatePhysics,
+        scripts: options.includeScripts !== false,
+    });
+    if (body) {
+        if (simulatePhysics) {
+            physics.dynamicBodies.push(actor);
+        } else {
+            physics.staticBodies.push(actor);
+        }
+    }
+
+    return options.returnActor === true ? actor : body;
+}
+
+function syncDynamicPhysicsBodies() {
+    physicsRuntime?.syncDynamicPhysicsBodies();
+}
+
+function rebuildTerrainPhysicsBody() {
+    physicsCore?.rebuildTerrainPhysicsBody();
+}
+
+function rebuildModelPhysicsBody() {
+    physicsCore?.rebuildModelPhysicsBody();
+}
+
+function destroyPlayerCharacter() {
+    physicsRuntime?.destroyPlayerCharacter();
+}
+
+function ensurePlayerCharacter() {
+    physicsRuntime?.ensurePlayerCharacter();
+}
+
+function syncCameraToCharacter() {
+    physicsRuntime?.syncCameraToCharacter();
+}
+
+function stepPhysics(delta) {
+    return physicsRuntime?.stepPhysics(delta) ?? {
+        total: 0,
+        step: 0,
+        sync: 0,
+        collisions: 0,
+    };
+}
+
+function updateLitePhysicsPools() {
+    for (let i = 0; i < litePools.length; i++) litePools[i].update();
+}
+
+/**
+ * Lightweight bulk physics path. No actor, no scripts, no scene graph entry —
+ * one InstancedMesh, one shared shape, parallel body array. Designed for
+ * spawning thousands of small dynamic boxes.
+ */
+function createLiteBoxPool(options = {}) {
+    if (!physics?.ready) {
+        console.warn('createLiteBoxPool: physics not ready yet');
+        return null;
+    }
+    const pool = createLitePhysicsPool({
+        physics,
+        scene,
+        ...options,
+    });
+    litePools.push(pool);
+    return pool;
+}
+
+function spawnLiteCubeStorm({
+    count = 3000,
+    halfExtent = 0.2,
+    spacing = 0.6,
+    origin = null,
+    color = 0x99bbff,
+    jitter = 0.05,
+} = {}) {
+    const pool = createLiteBoxPool({
+        capacity: count,
+        halfExtent,
+        color,
+    });
+    if (!pool) return null;
+
+    const dim = Math.ceil(Math.cbrt(count));
+    const baseOrigin = origin ?? {
+        x: (camera?.position?.x ?? 0),
+        y: (worldFloor?.position?.y ?? 0) + 5,
+        z: (camera?.position?.z ?? 0) - 4,
+    };
+    pool.spawnGrid({
+        origin: baseOrigin,
+        dimsX: dim,
+        dimsY: dim,
+        dimsZ: dim,
+        spacing,
+        jitter,
+    });
+    return pool;
+}
+
+if (typeof window !== 'undefined') {
+    window.spawnLiteCubeStorm = spawnLiteCubeStorm;
+    window.createLiteBoxPool = createLiteBoxPool;
+}
+
+function getActorRenderObject(prop) {
+    return getRenderComponent(prop)?.mesh ?? prop?.mesh ?? null;
+}
+function getActorBody(prop) {
+    if (!prop) return null;
+    return prop.body || getPhysicsBodyComponent(prop)?.body || null;
+}
+
+function isObjectWithinRoot(object, root) {
+    let current = object;
+    while (current) {
+        if (current === root) return true;
+        current = current.parent;
+    }
+    return false;
+}
+
+function getActorSelectionObject(prop, preferredObject = null) {
+    const root = getActorRenderObject(prop);
+    if (!root) return null;
+
+    if (preferredObject && isObjectWithinRoot(preferredObject, root)) {
+        return preferredObject;
+    }
+
+    if (objectScriptState.targetObjectUuid) {
+        const selectedObject = root.getObjectByProperty?.('uuid', objectScriptState.targetObjectUuid) ?? null;
+        if (selectedObject) {
+            return selectedObject;
+        }
+    }
+
+    return root;
+}
+
+function selectShowcaseActor(actorId, selectionObject = null) {
+    if (gameplay.active) return; // Only allow selection in Showcase mode
+    
+    const previousTargetId = objectScriptState.targetPropId;
+    objectScriptState.targetPropId = actorId || '';
+    objectScriptState.targetObjectUuid = '';
+    
+    if (blueprintState.active && actorId !== blueprintState.targetActor?.id) {
+        exitBlueprintEditor();
+    }
+    
+    if (actorId) {
+        const prop = getDynamicPropById(actorId);
+        const targetObject = getActorSelectionObject(prop, selectionObject);
+        objectScriptState.targetObjectUuid = targetObject?.uuid || '';
+        if (objectScriptEditorTarget) {
+            objectScriptEditorTarget.textContent = prop?.rootNode?.name || actorId || 'Actor';
+        }
+        if (transformControl && targetObject) {
+            transformControl.attach(targetObject);
+        }
+    } else {
+        if (objectScriptEditorTarget) {
+            objectScriptEditorTarget.textContent = 'None';
+        }
+        if (transformControl) {
+            transformControl.detach();
+        }
+    }
+    
+    if (previousTargetId !== objectScriptState.targetPropId) {
+        if (actorPhysicsEditorState.previewActorId && actorPhysicsEditorState.previewActorId !== objectScriptState.targetPropId) {
+            clearActorPhysicsPreview();
+        }
+        refreshSceneUI();
+    }
+}
+
+function buildPrimitiveActorMesh(kind) {
+    if (kind === 'sphere') {
+        return new THREE.Mesh(
+            new THREE.SphereGeometry(1, 28, 20),
+            new THREE.MeshStandardMaterial({
+                color: 0xf97316,
+                metalness: 0.14,
+                roughness: 0.34,
+                emissive: 0x331100,
+                emissiveIntensity: 0.28,
+            })
+        );
+    }
+    if (kind === 'cube') {
+    return new THREE.Mesh(
+        new THREE.BoxGeometry(2, 2, 2),
+        new THREE.MeshStandardMaterial({
+            color: 0x60a5fa,
+            metalness: 0.12,
+            roughness: 0.38,
+            emissive: 0x0b1220,
+            emissiveIntensity: 0.2,
+        })
+    );
+}
+    if (kind === 'capsule') {
+        return new THREE.Mesh(
+            new THREE.CapsuleGeometry(1, 2, 8, 16),
+            new THREE.MeshStandardMaterial({
+                color: 0x16a34a,
+                metalness: 0.1,
+                roughness: 0.4,
+                emissive: 0x052d12,
+                emissiveIntensity: 0.22,
+            })
+        );
+    }
+}
+
+// === extracted: objectMaterial (was lines 3876-4151 of original main.js) ===
+function spawnDDGIVolumeActor({ userData = null, position = null, size = null, options = {} } = {}) {
+    const camDir = camera ? new THREE.Vector3(0, 0, -1).applyQuaternion(camera.quaternion) : new THREE.Vector3(0, 0, -1);
+    const spawnPos = position
+        ? position.clone()
+        : (camera ? camera.position.clone().addScaledVector(camDir, 8) : new THREE.Vector3());
+    const dims = size ? size.clone() : new THREE.Vector3(32, 16, 32);
+    const geom = new THREE.BoxGeometry(dims.x, dims.y, dims.z);
+    const mat = new THREE.MeshBasicMaterial({
+        color: 0x4dffd2,
+        wireframe: true,
+        transparent: true,
+        opacity: 0.55,
+        depthWrite: false,
+        toneMapped: false,
+        fog: false,
+    });
+    const mesh = new THREE.Mesh(geom, mat);
+    mesh.position.copy(spawnPos);
+    mesh.userData.ddgiSkipReceive = true;
+    mesh.userData.ignoreForcedSceneShadows = true;
+    mesh.castShadow = false;
+    mesh.receiveShadow = false;
+
+    const actor = createActor({
+        mesh,
+        kind: 'ddgiVolume',
+        userData,
+        name: userData?.label || 'ddgi-volume',
+    });
+    if (!actor.hasComponent(TransformComponent)) {
+        actor.addComponent(new TransformComponent());
+    }
+    const ddgi = new DDGIVolumeComponent(options);
+    actor.addComponent(ddgi);
+
+    sceneSystem?.addActor(actor);
+    ensureActorIdentity(actor);
+
+    // Trigger BeginPlay manually so the volume registers right now (the engine's
+    // gameplay-mode lifecycle would otherwise wait for play).
+    try { ddgi.beginPlay(); } catch (e) { console.warn('[DDGI] beginPlay failed', e); }
+
+    return actor;
+}
+
+// === extracted: objectEvents (was lines 4261-4923 of original main.js) ===
+
+/**
+ * World-space raycast exposed to scripts and tools (e.g., the Physgun).
+ * Wraps physicsCore.castRay and attaches the owning actor for the hit body.
+ *
+ * @param {{x,y,z}} origin     World-space ray start.
+ * @param {{x,y,z}} direction  Unit direction vector.
+ * @param {number} [maxDist=1000]
+ * @returns {{hit:boolean, point?:{x,y,z}, normal?:{x,y,z}, distance?:number, actor?:object|null, bodyId?:number}}
+ */
+// Performance toggle: turn DDGI, volumetric fog, and post-process bloom off
+// (or on) at runtime without changing engine defaults. Each subsystem owns its
+// own enabled flag — we flip those here AND also gate the per-frame update
+// calls in the main render loop, so flipping this saves both render work and
+// CPU update work.
+// ──────────────────────────────────────────────────────────
+//  World Environment panel — Godot-style global graphics inspector
+// ──────────────────────────────────────────────────────────
+
+// ──────────────────────────────────────────────────────────
+//  Physgun (GMod-style grab/push/pull/fling tool)
+// ──────────────────────────────────────────────────────────
+
+const physgunState = {
+    equipped: false,
+    heldActor: null,
+    grabDistance: 5,
+    minDistance: 1.5,
+    maxDistance: 25,
+    // PD controller gains for the grab spring.
+    springK: 60,
+    damping: 6,
+    maxSpeed: 30,
+    flingImpulse: 18,
+};
+
+function physgunSetEquipped(equipped) {
+    physgunState.equipped = !!equipped;
+    if (!physgunState.equipped) physgunReleaseHeld();
+    const ui = document.getElementById('physgun-crosshair');
+    if (ui) ui.classList.toggle('physgun-active', physgunState.equipped);
+}
+
+function physgunReleaseHeld() {
+    physgunState.heldActor = null;
+}
+
+function physgunCameraRay() {
+    const origin = new THREE.Vector3();
+    camera.getWorldPosition(origin);
+    const direction = new THREE.Vector3();
+    camera.getWorldDirection(direction);
+    return { origin, direction: direction.normalize() };
+}
+
+function physgunGrabFromCamera() {
+    const { origin, direction } = physgunCameraRay();
+    const r = raycastWorld(origin, direction, 30);
+    if (!r.hit || !r.actor) return false;
+    // Only grab dynamic actors (must have a physics body that simulates).
+    const body = getActorBody(r.actor);
+    if (!body) return false;
+    physgunState.heldActor = r.actor;
+    physgunState.grabDistance = Math.max(physgunState.minDistance, Math.min(physgunState.maxDistance, r.distance));
+    // Wake the body so the spring can move it.
+    const phys = r.actor.getComponentByClass(PhysicsComponent);
+    phys?.activate?.();
+    return true;
+}
+
+function physgunFlingHeld() {
+    const actor = physgunState.heldActor;
+    if (!actor) return false;
+    const phys = actor.getComponentByClass(PhysicsComponent);
+    if (!phys) { physgunReleaseHeld(); return false; }
+    const { direction } = physgunCameraRay();
+    const v = new THREE.Vector3(
+        direction.x * physgunState.flingImpulse,
+        direction.y * physgunState.flingImpulse + 2.5,
+        direction.z * physgunState.flingImpulse,
+    );
+    phys.addImpulse(v);
+    physgunReleaseHeld();
+    return true;
+}
+
+function physgunPunt() {
+    const { origin, direction } = physgunCameraRay();
+    const r = raycastWorld(origin, direction, 50);
+    if (!r.hit || !r.actor) return false;
+    const phys = r.actor.getComponentByClass(PhysicsComponent);
+    if (!phys) return false;
+    phys.activate?.();
+    phys.addImpulse(new THREE.Vector3(
+        direction.x * physgunState.flingImpulse * 1.6,
+        direction.y * physgunState.flingImpulse * 1.6 + 1.5,
+        direction.z * physgunState.flingImpulse * 1.6,
+    ));
+    return true;
+}
+
+function physgunAdjustDistance(delta) {
+    physgunState.grabDistance = Math.max(
+        physgunState.minDistance,
+        Math.min(physgunState.maxDistance, physgunState.grabDistance + delta),
+    );
+}
+
+function tickPhysgun(delta) {
+    if (!physgunState.equipped || !physgunState.heldActor || !gameplay.active) return;
+    const actor = physgunState.heldActor;
+    const phys = actor.getComponentByClass(PhysicsComponent);
+    const mesh = getActorRenderObject(actor);
+    if (!phys || !mesh || !phys.isReady()) {
+        physgunReleaseHeld();
+        return;
+    }
+
+    const { origin, direction } = physgunCameraRay();
+    const target = origin.clone().addScaledVector(direction, physgunState.grabDistance);
+
+    const pos = mesh.getWorldPosition(new THREE.Vector3());
+    const vel = phys.getLinearVelocity();
+    // PD controller: a = K*(target - pos) - D*vel
+    const ax = physgunState.springK * (target.x - pos.x) - physgunState.damping * vel.x;
+    const ay = physgunState.springK * (target.y - pos.y) - physgunState.damping * vel.y;
+    const az = physgunState.springK * (target.z - pos.z) - physgunState.damping * vel.z;
+
+    // Integrate to a velocity directly (treat the spring as a velocity drive),
+    // clamped so we don't fling the body across the world.
+    let vx = vel.x + ax * delta;
+    let vy = vel.y + ay * delta;
+    let vz = vel.z + az * delta;
+    const speed = Math.sqrt(vx * vx + vy * vy + vz * vz);
+    if (speed > physgunState.maxSpeed) {
+        const k = physgunState.maxSpeed / speed;
+        vx *= k; vy *= k; vz *= k;
+    }
+    phys.setLinearVelocity(new THREE.Vector3(vx, vy, vz));
+    // Tame angular velocity so held objects don't spin chaotically.
+    const av = phys.getAngularVelocity();
+    phys.setAngularVelocity(new THREE.Vector3(av.x * 0.85, av.y * 0.85, av.z * 0.85));
+}
+
+/**
+ * Reset BeginPlay bookkeeping on every actor's lifecycle scripts so that
+ * BeginPlay re-fires on each Edit→Play transition. Called from gameplay entry.
+ */
+// === extracted: mouseActions (was lines 5698-5923 of original main.js) ===
+const container = document.getElementById('canvas-container');
+const processingOverlay = document.getElementById('processing-overlay');
+const loaderBar = document.getElementById('loader-bar');
+const processingStep = document.getElementById('processing-step');
+const processTrigger = document.getElementById('process-trigger');
+const downloadBtn = document.getElementById('download-asset');
+
+function setCameraMode(mode) {
+    if (mode === 'play') {
+        closeObjectScriptMenu();
+        closeObjectScriptEditor();
+        if (!gameplay.canPlay && physics.ready) {
+            gameplay.canPlay = true;
+            ensurePlayerCharacter();
+            updateGameplayUI();
+        }
+        if (!gameplay.active && !gameplay.pointerLocked) {
+            enterGameplay();
+        }
+        return;
+    }
+
+    exitGameplay();
+    resetShowcaseCamera(true);
+}
+
+function updateCameraModeButtons() {
+    if (showcaseModeBtn) {
+        showcaseModeBtn.classList.toggle('viewer-toggle-btn-active', !gameplay.active);
+    }
+
+    if (playModeBtn) {
+        playModeBtn.disabled = !gameplay.canPlay;
+        playModeBtn.classList.toggle('btn-disabled', !gameplay.canPlay);
+        playModeBtn.classList.toggle('viewer-toggle-btn-active', gameplay.active);
+    }
+}
+
+function isEditableElement(target) {
+    if (!(target instanceof HTMLElement)) return false;
+    if (target.isContentEditable) return true;
+    return ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName);
+}
+
+// === extracted: debugConsole (was lines 5985-6468 of original main.js) ===
+// === extracted: mobileControls (was lines 6469-6741 of original main.js) ===
+
+function getActorCoreInfo(actor) {
+    return actor?.userData?.actorCore ?? null;
+}
+
+function getActorCoreId(actor) {
+    const core = getActorCoreInfo(actor);
+    return core?.coreId || actor?.id || '';
+}
+
+function actorInheritsCore(actor) {
+    const core = getActorCoreInfo(actor);
+    return core?.inheritsRules === true && !!core.coreId && core.coreId !== actor?.id;
+}
+
+function getActorCoreSource(actor) {
+    const coreId = getActorCoreId(actor);
+    return coreId && coreId !== actor?.id ? getDynamicPropById(coreId) || actor : actor;
+}
+
+function serializeCoreVisualRules(actor) {
+    const mesh = getActorRenderObject(actor);
+    if (!mesh) return null;
+    return {
+        rootMaterial: serializeObjectMaterialState(mesh),
+        materialOverrides: serializeObjectMaterialOverrides(mesh),
+        components: serializeComponentTree(mesh),
+    };
+}
+
+function applyCoreVisualRulesToInstance(instanceActor, rules) {
+    const mesh = getActorRenderObject(instanceActor);
+    if (!mesh || !rules) return;
+    applyObjectMaterialState(mesh, rules.rootMaterial);
+    if (Array.isArray(rules.materialOverrides) && rules.materialOverrides.length > 0) {
+        applyObjectMaterialOverrides(mesh, rules.materialOverrides);
+    }
+    deserializeComponentTree(mesh, JSON.parse(JSON.stringify(rules.components || [])));
+    mesh.userData.hasMaterialOverrides = true;
+    mesh.updateMatrixWorld(true);
+    if (!gameplay.active) {
+        rebuildActorPhysics(instanceActor);
+    }
+}
+
+function syncActorCoreInstances() {
+    if (!sceneSystem?.actors?.size) return;
+    const actors = Array.from(sceneSystem.actors);
+    const cores = actors.filter((actor) => !actorInheritsCore(actor));
+    const liveCoreIds = new Set(cores.map((actor) => actor.id));
+
+    actorCoreSyncState.forEach((_entry, coreId) => {
+        if (!liveCoreIds.has(coreId)) actorCoreSyncState.delete(coreId);
+    });
+
+    cores.forEach((coreActor) => {
+        const linked = actors.filter((actor) => actorInheritsCore(actor) && getActorCoreSource(actor)?.id === coreActor.id);
+        if (!linked.length) return;
+        const rules = serializeCoreVisualRules(coreActor);
+        if (!rules) return;
+        const signature = JSON.stringify(rules);
+        if (actorCoreSyncState.get(coreActor.id)?.signature === signature) return;
+        actorCoreSyncState.set(coreActor.id, { signature });
+        linked.forEach((instanceActor) => applyCoreVisualRulesToInstance(instanceActor, rules));
+    });
+}
+
+function focusSceneActor(actor) {
+    const actorMesh = getActorRenderObject(actor);
+    if (gameplay.active || !actorMesh) return;
+
+    focusShowcaseCameraOnObject(actorMesh);
+}
+
+function getObjectFocusFrame(object) {
+    if (!object) return null;
+
+    tempBoxA.makeEmpty();
+    tempBoxA.setFromObject(object, true);
+
+    const targetPos = new THREE.Vector3();
+    const size = new THREE.Vector3();
+
+    if (tempBoxA.isEmpty()) {
+        object.getWorldPosition(targetPos);
+        size.setScalar(0.7);
+    } else {
+        tempBoxA.getCenter(targetPos);
+        tempBoxA.getSize(size);
+    }
+
+    const radius = Math.max(size.length() * 0.5, 0.35);
+    const vFov = THREE.MathUtils.degToRad(camera.fov || 45);
+    const hFov = 2 * Math.atan(Math.tan(vFov * 0.5) * Math.max(camera.aspect || 1, 0.1));
+    const fitFov = Math.max(0.1, Math.min(vFov, hFov));
+    const distance = THREE.MathUtils.clamp(
+        (radius / Math.sin(fitFov * 0.5)) * 1.65,
+        Math.max(2.1, radius * 2.9),
+        90
+    );
+
+    const viewDir = new THREE.Vector3().subVectors(camera.position, targetPos);
+    if (viewDir.lengthSq() < 0.0001) {
+        viewDir.set(1, 0.45, 1);
+    }
+    viewDir.normalize();
+
+    if (viewDir.y < 0.24) {
+        viewDir.y = 0.34;
+        viewDir.normalize();
+    }
+
+    return {
+        target: targetPos,
+        cameraPosition: targetPos.clone().addScaledVector(viewDir, distance),
+    };
+}
+
+function focusShowcaseCameraOnObject(object, { duration = 0.6 } = {}) {
+    if (gameplay.active || !camera || !object) return;
+
+    const frame = getObjectFocusFrame(object);
+    if (!frame) return;
+
+    showcase.velocity.set(0, 0, 0);
+    gsap?.killTweensOf(camera.position);
+
+    if (gsap) {
+        gsap.to(camera.position, {
+            x: frame.cameraPosition.x,
+            y: frame.cameraPosition.y,
+            z: frame.cameraPosition.z,
+            duration,
+            overwrite: true,
+            ease: 'power2.out',
+            onUpdate: () => {
+                syncShowcaseAnglesToFaceTarget(frame.target);
+                applyShowcaseCameraRotation();
+            }
+        });
+    } else {
+        camera.position.copy(frame.cameraPosition);
+        syncShowcaseAnglesToFaceTarget(frame.target);
+        applyShowcaseCameraRotation();
+    }
+}
+
+// --- Initialization ---
+async function init() {
+    // Mobile Detection (full applyMobileModeState runs after wireExtractedModules
+    // because it depends on injected refs in src/debug/console.js)
+    const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) || window.matchMedia('(pointer: coarse)').matches;
+    mobileState.detected = isMobile;
+    mobileState.forced = false;
+    mobileState.enabled = isMobile;
+    document.body.classList.toggle('is-mobile', isMobile);
+
+    // Add listeners immediately so UI is responsive even if WASM is loading
+    document.getElementById('load-sample').addEventListener('click', (e) => {
+        e.stopPropagation();
+        loadSample();
+    });
+
+    browseModelBtn = document.getElementById('open-model-menu');
+    sceneUiPanel = document.getElementById('scene-ui-panel');
+    sceneUiCount = document.getElementById('scene-ui-count');
+    sceneUiList = document.getElementById('scene-ui-list');
+    showcaseModeBtn = document.getElementById('camera-showcase');
+    playModeBtn = document.getElementById('camera-play');
+    openActorEditorBtn = document.getElementById('open-actor-editor');
+    playTestSoundBtn = document.getElementById('play-test-sound-btn');
+    playTestSoundStatus = document.getElementById('play-test-sound-status');
+    multiplayerServerUrlInput = document.getElementById('multiplayer-server-url');
+    multiplayerRoomInput = document.getElementById('multiplayer-room');
+    multiplayerConnectBtn = document.getElementById('multiplayer-connect');
+    multiplayerDisconnectBtn = document.getElementById('multiplayer-disconnect');
+    multiplayerStatusValue = document.getElementById('multiplayer-status');
+    multiplayerPlayerCountValue = document.getElementById('multiplayer-player-count');
+    importPropBtn = document.getElementById('import-prop-menu');
+    propFileInput = document.getElementById('prop-file-input');
+    importedPropList = document.getElementById('imported-prop-list');
+    importedPropLibrary = document.getElementById('imported-prop-library');
+    propImportDefaultStatus = document.getElementById('prop-import-default-status');
+    resetPropImportDefaultBtn = document.getElementById('reset-prop-import-default');
+    actorEditor = document.getElementById('actor-editor');
+    actorEditorSummary = document.getElementById('actor-editor-summary');
+    actorEditorStatus = document.getElementById('actor-editor-status');
+    actorKindSelect = document.getElementById('actor-kind-select');
+    actorLabelInput = document.getElementById('actor-label-input');
+    actorScaleInput = document.getElementById('actor-scale-input');
+    actorImportedTemplateSelect = document.getElementById('actor-imported-template-select');
+    actorVehicleBodyTemplateSelect = document.getElementById('actor-vehicle-body-template-select');
+    actorVehicleWheelTemplateSelect = document.getElementById('actor-vehicle-wheel-template-select');
+    vehicleTemplateImportInput = document.getElementById('vehicle-template-import-input');
+    actorComponentCollisionInput = document.getElementById('actor-component-collision');
+    actorComponentPhysicsInput = document.getElementById('actor-component-physics');
+    actorComponentScriptsInput = document.getElementById('actor-component-scripts');
+    actorEditorCreateBtn = document.getElementById('actor-editor-create');
+    actorEditorOpenScriptBtn = document.getElementById('actor-editor-open-script');
+    actorEditorCancelBtn = document.getElementById('actor-editor-cancel');
+    propCollisionPrompt = document.getElementById('prop-collision-prompt');
+    propCollisionCopy = document.getElementById('prop-collision-copy');
+    propCollisionRemember = document.getElementById('prop-collision-remember');
+    propCollisionSimpleBtn = document.getElementById('prop-collision-simple');
+    propCollisionComplexBtn = document.getElementById('prop-collision-complex');
+    propCollisionCancelBtn = document.getElementById('prop-collision-cancel');
+    inputActionsOpenBtn = document.getElementById('open-input-actions');
+    inputActionsEditor = document.getElementById('input-actions-editor');
+    inputActionLeftBtn = document.getElementById('input-action-left');
+    inputActionRightBtn = document.getElementById('input-action-right');
+    inputActionMode = document.getElementById('input-actions-mode');
+    inputActionEditorInput = document.getElementById('input-action-editor-input');
+    inputActionsEditorStatus = document.getElementById('input-actions-editor-status');
+    mouseActionApplyBtn = document.getElementById('apply-mouse-actions');
+    mouseActionResetBtn = document.getElementById('reset-mouse-actions');
+    inputActionsCloseBtn = document.getElementById('input-actions-close');
+    mouseActionStatus = document.getElementById('mouse-action-status');
+    objectScriptMenu = document.getElementById('object-script-menu');
+    objectScriptTickActionBtn = document.getElementById('object-script-action-tick');
+    objectScriptCollisionActionBtn = document.getElementById('object-script-action-collision');
+    objectScriptEditor = document.getElementById('object-script-editor');
+    objectScriptEditorTitle = document.getElementById('object-script-editor-title');
+    objectScriptEditorTarget = document.getElementById('object-script-editor-target');
+    objectScriptEditorMode = document.getElementById('object-script-editor-mode');
+    objectScriptTickToggleRow = document.getElementById('object-script-tick-toggle-row');
+    objectScriptTickToggleInput = document.getElementById('object-script-tick-toggle');
+    objectScriptEditorInput = document.getElementById('object-script-editor-input');
+    objectScriptEditorStatus = document.getElementById('object-script-editor-status');
+    objectScriptEditorApplyBtn = document.getElementById('object-script-editor-apply');
+    objectScriptEditorClearBtn = document.getElementById('object-script-editor-clear');
+    objectScriptEditorCancelBtn = document.getElementById('object-script-editor-cancel');
+    debugConsole = document.getElementById('debug-console');
+    debugConsoleOutput = document.getElementById('debug-console-output');
+    debugConsoleInput = document.getElementById('debug-console-input');
+    debugConsoleFooter = document.getElementById('debug-console-footer');
+    debugStatsOverlay = document.getElementById('debug-stats-overlay');
+    engineAudioDebugEl = document.getElementById('engine-audio-debug');
+    postProcessUiRefs = {
+        targetGlobalBtn: document.getElementById('post-process-target-global'),
+        targetVolumeBtn: document.getElementById('post-process-target-volume'),
+        exposureInput: document.getElementById('post-process-exposure'),
+        exposureValue: document.getElementById('post-process-exposure-value'),
+        bloomStrengthInput: document.getElementById('post-process-bloom-strength'),
+        bloomStrengthValue: document.getElementById('post-process-bloom-strength-value'),
+        bloomRadiusInput: document.getElementById('post-process-bloom-radius'),
+        bloomRadiusValue: document.getElementById('post-process-bloom-radius-value'),
+        bloomThresholdInput: document.getElementById('post-process-bloom-threshold'),
+        bloomThresholdValue: document.getElementById('post-process-bloom-threshold-value'),
+        blendSpeedInput: document.getElementById('post-process-blend-speed'),
+        blendSpeedValue: document.getElementById('post-process-blend-speed-value'),
+        priorityInput: document.getElementById('post-process-priority'),
+        sizeXInput: document.getElementById('post-process-size-x'),
+        sizeYInput: document.getElementById('post-process-size-y'),
+        sizeZInput: document.getElementById('post-process-size-z'),
+        placeVolumeBtn: document.getElementById('post-process-place-volume'),
+        removeVolumeBtn: document.getElementById('post-process-remove-volume'),
+        toggleBoundsBtn: document.getElementById('post-process-toggle-bounds'),
+        applyBtn: document.getElementById('post-process-apply-settings'),
+        status: document.getElementById('post-process-status'),
+    };
+    shadowDebugUiRefs = {
+        forceOffBtn: document.getElementById('debug-force-mesh-shadows-off'),
+        forceOnBtn: document.getElementById('debug-force-mesh-shadows-on'),
+        applyBtn: document.getElementById('debug-apply-mesh-shadows'),
+        status: document.getElementById('debug-shadow-status'),
+    };
+    perfModeUiRefs = {
+        offBtn: document.getElementById('perf-mode-off'),
+        onBtn: document.getElementById('perf-mode-on'),
+        status: document.getElementById('perf-mode-status'),
+    };
+
+    // World Environment panel refs — every toggle button, slider input, and
+    // value-display span. Lookups are tolerant: the panel may be absent in
+    // older index.html copies; null refs short-circuit gracefully in the
+    // updateWorldEnvUi / handler bodies.
+    worldEnvUiRefs = {
+        summaryValue: document.getElementById('we-summary-value'),
+        masterOnBtn: document.getElementById('we-master-on'),
+        masterOffBtn: document.getElementById('we-master-off'),
+        masterPerfBtn: document.getElementById('we-master-perf'),
+        masterStatus: document.getElementById('we-master-status'),
+        skyOff: document.getElementById('we-sky-off'),
+        skyOn: document.getElementById('we-sky-on'),
+        skyPreset: document.getElementById('we-sky-preset'),
+        skyBlurriness: document.getElementById('we-sky-blurriness'),
+        skyBlurrinessValue: document.getElementById('we-sky-blurriness-value'),
+        ambientOff: document.getElementById('we-ambient-off'),
+        ambientOn: document.getElementById('we-ambient-on'),
+        ambientIntensity: document.getElementById('we-ambient-intensity'),
+        ambientIntensityValue: document.getElementById('we-ambient-intensity-value'),
+        hemiOff: document.getElementById('we-hemi-off'),
+        hemiOn: document.getElementById('we-hemi-on'),
+        hemiIntensity: document.getElementById('we-hemi-intensity'),
+        hemiIntensityValue: document.getElementById('we-hemi-intensity-value'),
+        sunOff: document.getElementById('we-sun-off'),
+        sunOn: document.getElementById('we-sun-on'),
+        sunShadow: document.getElementById('we-sun-shadow'),
+        sunIntensity: document.getElementById('we-sun-intensity'),
+        sunIntensityValue: document.getElementById('we-sun-intensity-value'),
+        exposure: document.getElementById('we-tonemap-exposure'),
+        exposureValue: document.getElementById('we-tonemap-exposure-value'),
+        bloomOff: document.getElementById('we-bloom-off'),
+        bloomOn: document.getElementById('we-bloom-on'),
+        bloomStrength: document.getElementById('we-bloom-strength'),
+        bloomStrengthValue: document.getElementById('we-bloom-strength-value'),
+        bloomRadius: document.getElementById('we-bloom-radius'),
+        bloomRadiusValue: document.getElementById('we-bloom-radius-value'),
+        bloomThreshold: document.getElementById('we-bloom-threshold'),
+        bloomThresholdValue: document.getElementById('we-bloom-threshold-value'),
+        fogOff: document.getElementById('we-fog-off'),
+        fogOn: document.getElementById('we-fog-on'),
+        fogDensity: document.getElementById('we-fog-density'),
+        fogDensityValue: document.getElementById('we-fog-density-value'),
+        fogOpacity: document.getElementById('we-fog-opacity'),
+        fogOpacityValue: document.getElementById('we-fog-opacity-value'),
+        ddgiOff: document.getElementById('we-ddgi-off'),
+        ddgiOn: document.getElementById('we-ddgi-on'),
+        ddgiProbes: document.getElementById('we-ddgi-probes'),
+        ddgiProbesValue: document.getElementById('we-ddgi-probes-value'),
+        ddgiIntensity: document.getElementById('we-ddgi-intensity'),
+        ddgiIntensityValue: document.getElementById('we-ddgi-intensity-value'),
+        shadowsOff: document.getElementById('we-shadows-off'),
+        shadowsOn: document.getElementById('we-shadows-on'),
+        resetBtn: document.getElementById('we-reset-defaults'),
+    };
+
+    renderDebugConsoleOutput();
+    debugConsoleInput?.addEventListener('keydown', handleDebugConsoleInputKeydown);
+
+    postProcessUiRefs?.targetGlobalBtn?.addEventListener('click', () => {
+        postProcessUiState.target = 'global';
+        syncPostProcessVolumeUi();
+    });
+    postProcessUiRefs?.targetVolumeBtn?.addEventListener('click', () => {
+        postProcessUiState.target = 'volume';
+        syncPostProcessVolumeUi();
+    });
+
+    [
+        postProcessUiRefs?.exposureInput,
+        postProcessUiRefs?.bloomStrengthInput,
+        postProcessUiRefs?.bloomRadiusInput,
+        postProcessUiRefs?.bloomThresholdInput,
+        postProcessUiRefs?.blendSpeedInput,
+    ].forEach((input) => {
+        input?.addEventListener('input', () => {
+            updatePostProcessSliderLabels();
+            applyPostProcessSettingsFromUi({ reloadInputs: false });
+        });
+    });
+
+    [
+        postProcessUiRefs?.priorityInput,
+        postProcessUiRefs?.sizeXInput,
+        postProcessUiRefs?.sizeYInput,
+        postProcessUiRefs?.sizeZInput,
+    ].forEach((input) => {
+        input?.addEventListener('change', () => {
+            applyPostProcessSettingsFromUi({ reloadInputs: false });
+        });
+    });
+
+    postProcessUiRefs?.placeVolumeBtn?.addEventListener('click', () => {
+        postProcessUiState.target = 'volume';
+        applyPostProcessSettingsFromUi({ createVolumeIfNeeded: true, placeVolumeAtCamera: true, reloadInputs: true });
+    });
+    postProcessUiRefs?.removeVolumeBtn?.addEventListener('click', () => {
+        postProcessVolumeManager?.removeEditorVolume?.();
+        postProcessVolumeManager?.update?.(1);
+        syncPostProcessVolumeUi();
+    });
+    postProcessUiRefs?.toggleBoundsBtn?.addEventListener('click', () => {
+        const snapshot = postProcessVolumeManager?.getSnapshot?.();
+        postProcessVolumeManager?.setDebugVisible?.(!snapshot?.debugVisible);
+        syncPostProcessVolumeUi({ reloadInputs: false });
+    });
+    postProcessUiRefs?.applyBtn?.addEventListener('click', () => {
+        applyPostProcessSettingsFromUi({ createVolumeIfNeeded: postProcessUiState.target === 'volume', reloadInputs: true });
+    });
+    shadowDebugUiRefs?.forceOffBtn?.addEventListener('click', () => {
+        setForceAllSceneMeshShadowsEnabled(false);
+    });
+    shadowDebugUiRefs?.forceOnBtn?.addEventListener('click', () => {
+        setForceAllSceneMeshShadowsEnabled(true);
+    });
+    shadowDebugUiRefs?.applyBtn?.addEventListener('click', () => {
+        forceAllSceneMeshShadows();
+    });
+    updateShadowDebugUi();
+
+    perfModeUiRefs?.offBtn?.addEventListener('click', () => {
+        setPerfModeEnabled(false);
+    });
+    perfModeUiRefs?.onBtn?.addEventListener('click', () => {
+        setPerfModeEnabled(true);
+    });
+    updatePerfModeUi();
+
+    // World Environment panel: load saved state, wire all togglers + sliders,
+    // then call applyWorldEnvState once so the engine boots into the user's
+    // last-saved configuration. Each handler mutates the relevant slice of
+    // worldEnvState then re-applies — keeps the UI and runtime in sync without
+    // duplicating logic.
+    loadWorldEnvFromStorage();
+
+    const wireToggle = (offBtn, onBtn, getStateOff, getStateOn) => {
+        offBtn?.addEventListener('click', () => { getStateOff(); applyWorldEnvState(); });
+        onBtn?.addEventListener('click', () => { getStateOn(); applyWorldEnvState(); });
+    };
+    const wireSlider = (input, key, setter, parser = parseFloat) => {
+        input?.addEventListener('input', () => {
+            const v = parser(input.value);
+            if (Number.isFinite(v)) {
+                setter(v);
+                applyWorldEnvState({ switchSky: false });
+            }
+        });
+    };
+
+    worldEnvUiRefs?.masterOnBtn?.addEventListener('click', () => setWorldEnvMaster('on'));
+    worldEnvUiRefs?.masterOffBtn?.addEventListener('click', () => setWorldEnvMaster('off'));
+    worldEnvUiRefs?.masterPerfBtn?.addEventListener('click', () => setWorldEnvMaster('perf'));
+    worldEnvUiRefs?.resetBtn?.addEventListener('click', () => resetWorldEnvDefaults());
+
+    wireToggle(worldEnvUiRefs?.skyOff, worldEnvUiRefs?.skyOn,
+        () => { worldEnvState.sky.enabled = false; },
+        () => { worldEnvState.sky.enabled = true; });
+    worldEnvUiRefs?.skyPreset?.addEventListener('change', () => {
+        worldEnvState.sky.preset = worldEnvUiRefs.skyPreset.value;
+        applyWorldEnvState();
+    });
+    wireSlider(worldEnvUiRefs?.skyBlurriness, 'sky.blurriness', (v) => { worldEnvState.sky.blurriness = v; });
+
+    wireToggle(worldEnvUiRefs?.ambientOff, worldEnvUiRefs?.ambientOn,
+        () => { worldEnvState.ambient.enabled = false; },
+        () => { worldEnvState.ambient.enabled = true; });
+    wireSlider(worldEnvUiRefs?.ambientIntensity, 'ambient.intensity', (v) => { worldEnvState.ambient.intensity = v; });
+
+    wireToggle(worldEnvUiRefs?.hemiOff, worldEnvUiRefs?.hemiOn,
+        () => { worldEnvState.hemi.enabled = false; },
+        () => { worldEnvState.hemi.enabled = true; });
+    wireSlider(worldEnvUiRefs?.hemiIntensity, 'hemi.intensity', (v) => { worldEnvState.hemi.intensity = v; });
+
+    wireToggle(worldEnvUiRefs?.sunOff, worldEnvUiRefs?.sunOn,
+        () => { worldEnvState.sun.enabled = false; },
+        () => { worldEnvState.sun.enabled = true; });
+    worldEnvUiRefs?.sunShadow?.addEventListener('change', () => {
+        worldEnvState.sun.castShadow = !!worldEnvUiRefs.sunShadow.checked;
+        applyWorldEnvState({ switchSky: false });
+    });
+    wireSlider(worldEnvUiRefs?.sunIntensity, 'sun.intensity', (v) => { worldEnvState.sun.intensity = v; });
+
+    wireSlider(worldEnvUiRefs?.exposure, 'tonemap.exposure', (v) => { worldEnvState.tonemap.exposure = v; });
+
+    wireToggle(worldEnvUiRefs?.bloomOff, worldEnvUiRefs?.bloomOn,
+        () => { worldEnvState.bloom.enabled = false; },
+        () => { worldEnvState.bloom.enabled = true; });
+    wireSlider(worldEnvUiRefs?.bloomStrength, 'bloom.strength', (v) => { worldEnvState.bloom.strength = v; });
+    wireSlider(worldEnvUiRefs?.bloomRadius, 'bloom.radius', (v) => { worldEnvState.bloom.radius = v; });
+    wireSlider(worldEnvUiRefs?.bloomThreshold, 'bloom.threshold', (v) => { worldEnvState.bloom.threshold = v; });
+
+    wireToggle(worldEnvUiRefs?.fogOff, worldEnvUiRefs?.fogOn,
+        () => { worldEnvState.fog.enabled = false; },
+        () => { worldEnvState.fog.enabled = true; });
+    wireSlider(worldEnvUiRefs?.fogDensity, 'fog.density', (v) => { worldEnvState.fog.density = v; });
+    wireSlider(worldEnvUiRefs?.fogOpacity, 'fog.opacity', (v) => { worldEnvState.fog.opacity = v; });
+
+    wireToggle(worldEnvUiRefs?.ddgiOff, worldEnvUiRefs?.ddgiOn,
+        () => { worldEnvState.ddgi.enabled = false; },
+        () => { worldEnvState.ddgi.enabled = true; });
+    wireSlider(worldEnvUiRefs?.ddgiProbes, 'ddgi.probesPerFrame',
+        (v) => { worldEnvState.ddgi.probesPerFrame = Math.round(v); }, (s) => parseInt(s, 10));
+    wireSlider(worldEnvUiRefs?.ddgiIntensity, 'ddgi.intensity', (v) => { worldEnvState.ddgi.intensity = v; });
+
+    wireToggle(worldEnvUiRefs?.shadowsOff, worldEnvUiRefs?.shadowsOn,
+        () => { worldEnvState.shadows.enabled = false; },
+        () => { worldEnvState.shadows.enabled = true; });
+
+    // Apply once now that all controllers + UI are wired. This pushes the
+    // (possibly-restored-from-localStorage) state through every subsystem and
+    // syncs the panel display. Any controllers not yet ready are no-ops thanks
+    // to the optional-chaining inside applyWorldEnvState.
+    applyWorldEnvState({ persist: false });
+
+    if (browseModelBtn) {
+        browseModelBtn.addEventListener('click', () => {
+            document.getElementById('file-input').click();
+        });
+    }
+
+    if (importPropBtn) {
+        importPropBtn.addEventListener('click', () => {
+            propFileInput.value = '';
+            propFileInput.click();
+        });
+    }
+
+    propFileInput?.addEventListener('change', async (event) => {
+        const file = event.target.files[0];
+        event.target.value = '';
+        if (!file) return;
+        await importPhysicsProp(file, {});
+    });
+
+    resetPropImportDefaultBtn?.addEventListener('click', () => {
+        importedPropState.futureCollisionMode = null;
+        updatePropImportStatus();
+    });
+
+    propCollisionSimpleBtn?.addEventListener('click', () => {
+        resolvePropCollisionPrompt({
+            mode: 'simple',
+            remember: !!propCollisionRemember?.checked,
+        });
+    });
+
+    propCollisionComplexBtn?.addEventListener('click', () => {
+        resolvePropCollisionPrompt({
+            mode: 'complex',
+            remember: !!propCollisionRemember?.checked,
+        });
+    });
+
+    propCollisionCancelBtn?.addEventListener('click', () => resolvePropCollisionPrompt(null));
+
+    openActorEditorBtn?.addEventListener('click', () => openActorEditor());
+    playTestSoundBtn?.addEventListener('click', () => {
+        void playAudioTestCue();
+    });
+    const actorColorEnabledEl = document.getElementById('actor-color-enabled');
+    const actorColorInputEl = document.getElementById('actor-color-input');
+    actorColorEnabledEl?.addEventListener('change', () => {
+        if (actorColorInputEl) actorColorInputEl.disabled = !actorColorEnabledEl.checked;
+    });
+    actorKindSelect?.addEventListener('change', () => syncActorEditorUi());
+    actorImportedTemplateSelect?.addEventListener('change', () => syncActorEditorUi());
+    actorVehicleBodyTemplateSelect?.addEventListener('change', () => handleVehicleTemplateSelectChange('body'));
+    actorVehicleWheelTemplateSelect?.addEventListener('change', () => handleVehicleTemplateSelectChange('wheel'));
+    vehicleTemplateImportInput?.addEventListener('change', async (event) => {
+        const file = event.target.files?.[0];
+        const slot = pendingVehicleTemplateImportSlot;
+        pendingVehicleTemplateImportSlot = null;
+        event.target.value = '';
+        if (!file || !slot) return;
+
+        const template = await importPhysicsProp(file, {});
+        const select = slot === 'body' ? actorVehicleBodyTemplateSelect : actorVehicleWheelTemplateSelect;
+        if (template?.id && select) {
+            // populateVehicleSelect already re-ran via registerImportedPropTemplate;
+            // just select the freshly imported template.
+            select.value = template.id;
+        } else if (select) {
+            select.value = '';
+        }
+        syncActorEditorUi();
+    });
+    actorComponentCollisionInput?.addEventListener('change', () => syncActorEditorUi());
+    actorComponentPhysicsInput?.addEventListener('change', () => syncActorEditorUi());
+    actorComponentScriptsInput?.addEventListener('change', () => syncActorEditorUi());
+    actorEditorCreateBtn?.addEventListener('click', () => {
+        spawnActorFromEditor({ openScriptEditor: false });
+    });
+    actorEditorOpenScriptBtn?.addEventListener('click', () => {
+        spawnActorFromEditor({ openScriptEditor: true });
+    });
+    actorEditorCancelBtn?.addEventListener('click', () => closeActorEditor());
+
+    inputActionsOpenBtn?.addEventListener('click', () => openInputActionsEditor());
+    inputActionLeftBtn?.addEventListener('click', () => openInputActionsEditor('left'));
+    inputActionRightBtn?.addEventListener('click', () => openInputActionsEditor('right'));
+    inputActionEditorInput?.addEventListener('input', () => {
+        updateSelectedMouseActionSource();
+        syncInputActionsEditor();
+        saveMouseActionDrafts();
+    });
+
+    mouseActionApplyBtn?.addEventListener('click', () => applyMouseActionScripts({ persist: true }));
+    mouseActionResetBtn?.addEventListener('click', () => resetMouseActionScripts());
+    inputActionsCloseBtn?.addEventListener('click', () => closeInputActionsEditor());
+    objectScriptTickActionBtn?.addEventListener('click', () => openObjectScriptEditor('tick'));
+    objectScriptCollisionActionBtn?.addEventListener('click', () => openObjectScriptEditor('collision'));
+    objectScriptEditorMode?.addEventListener('change', () => {
+        objectScriptState.targetEvent = objectScriptEditorMode.value === 'collision' ? 'collision' : 'tick';
+        syncObjectScriptEditor();
+    });
+    objectScriptEditorApplyBtn?.addEventListener('click', () => {
+        const prop = getDynamicPropById(objectScriptState.targetPropId);
+        if (!prop || !objectScriptEditorInput) return;
+        updatePropScriptSource(prop, objectScriptState.targetEvent, objectScriptEditorInput.value, { persist: true, notify: true });
+    });
+    objectScriptTickToggleInput?.addEventListener('change', () => {
+        const prop = getDynamicPropById(objectScriptState.targetPropId);
+        if (!prop) return;
+        setPropTickEventEnabled(prop, !!objectScriptTickToggleInput.checked, { persist: true });
+    });
+    objectScriptEditorClearBtn?.addEventListener('click', () => {
+        const prop = getDynamicPropById(objectScriptState.targetPropId);
+        if (!prop) return;
+        clearPropScriptSource(prop, objectScriptState.targetEvent);
+        syncObjectScriptEditor();
+    });
+    objectScriptEditorCancelBtn?.addEventListener('click', () => closeObjectScriptEditor());
+    document.addEventListener('pointerdown', handleObjectScriptGlobalPointerDown, true);
+    document.addEventListener('keydown', handleObjectScriptKeydown);
+
+    showcaseModeBtn?.addEventListener('click', () => setCameraMode('showcase'));
+    playModeBtn?.addEventListener('click', () => setCameraMode('play'));
+
+    setupDropHandlers();
+
+    // Slider listener
+    const slider = document.getElementById('ratio-slider');
+    const ratioValue = document.getElementById('ratio-value');
+    if (slider) {
+        slider.addEventListener('input', (e) => {
+            const val = Math.round(e.target.value * 100);
+            if (ratioValue) {
+                ratioValue.textContent = `${val}%`;
+            }
+        });
+    }
+
+    if (!navigator.gpu) {
+        const errorMsg = "WebGPU is not supported in this browser. Please use Chrome/Edge (v113+) or enable it in your flags.";
+        console.error(errorMsg);
+        alert(errorMsg);
+        // We can't continue initialization with WebGPURenderer if it's missing
+        return;
+    }
+
+    await MeshoptSimplifier.ready;
+    console.log("MeshoptSimplifier ready");
+    await initPhysics();
+
+    scene = new THREE.Scene();
+    sceneSystem = createSceneSystem(scene);
+    sceneSystem.onActorsChanged = refreshSceneUI;
+    
+    environmentController = createEnvironmentController({
+        scene,
+        getAmbientLight: () => ambientLight,
+        getHemiLight: () => hemiLight,
+    });
+
+    camera = new THREE.PerspectiveCamera(45, container.clientWidth / container.clientHeight, 0.1, 1000);
+    camera.position.copy(SHOWCASE_CAMERA_POSITION);
+    camera.rotation.order = 'YXZ';
+    syncShowcaseAnglesFromTarget(SHOWCASE_CAMERA_TARGET);
+    applyShowcaseCameraRotation();
+    scene.add(camera);
+    volumetricFogController = createVolumetricFog({
+        scene,
+        camera,
+    });
+    runtimeAudio.listener = new SoundGeneratorAudioListener();
+    camera.add(runtimeAudio.listener);
+
+    renderer = new WebGPURenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    renderer.localClippingEnabled = true; // Essential for the reflection
+    renderer.domElement.tabIndex = 0;
+    container.appendChild(renderer.domElement);
+    await renderer.init();
+
+    // ── Post-processing: bloom over the scene's emissive output ─────────────
+    // Uses an MRT pass so bloom only picks up materials with non-zero emissive
+    // (lights, headlights/taillights, accent stripes) instead of every bright
+    // pixel — keeps the world from looking hazy.
+    const scenePass = pass(scene, camera);
+    scenePass.setMRT(mrt({
+        output: output,
+        emissive: emissive,
+    }));
+    const sceneColor = scenePass.getTextureNode('output');
+    const sceneEmissive = scenePass.getTextureNode('emissive');
+    const bloomNode = bloom(sceneEmissive, globalPostProcessUniforms.bloomStrength, globalPostProcessUniforms.bloomRadius, globalPostProcessUniforms.bloomThreshold);
+    postProcessing = new PostProcessing(renderer);
+    postProcessing.outputNode = sceneColor.add(bloomNode);
+
+    postProcessVolumeManager = createPostProcessVolumeManager({
+        scene,
+        camera,
+        renderer,
+        globalUniforms: globalPostProcessUniforms
+    });
+    syncPostProcessVolumeUi();
+
+    getDDGIManager().init({
+        scene,
+        renderer,
+        camera,
+        getDirectionalLight: () => mainDirectionalLight,
+    });
+    if (typeof window !== 'undefined') {
+        window.__ddgi = getDDGIManager();
+    }
+
+    // Initialize TransformControls for gizmo manipulation
+    transformControl = new TransformControls(camera, renderer.domElement);
+    transformControl.setSize(1.5); // Make gizmo hit area larger
+    transformControl.addEventListener('change', () => {
+        if (blueprintState.active) {
+            updateBlueprintDetailsUI();
+        }
+    });
+    transformControl.addEventListener('dragging-changed', (event) => {
+        showcase.looking = false;
+        if (!event.value) {
+            if (blueprintState.active) {
+                const prop = getDynamicPropById(objectScriptState.targetPropId);
+                if (prop) rebuildActorPhysics(prop);
+            } else {
+                syncTransformToPhysics();
+            }
+            transformControl.justFinishedDragging = true;
+            editorHistory.captureState();
+            setTimeout(() => transformControl.justFinishedDragging = false, 100);
+        }
+    });
+    scene.add(transformControl.getHelper());
+
+    // Wire extracted modules now that scene/camera/renderer/transformControl/sceneSystem
+    // and DOM refs all exist. Must happen before any module-bound helper is called.
+    wireExtractedModules();
+
+    syncTransformControlState();
+
+    // Initialize widget system AFTER renderer is set up
+    widgetManager = new WidgetManager(container);
+    lightGridController = createLightGridController({
+        scene,
+        gsap,
+        getRenderer: () => renderer,
+        getCamera: () => camera,
+        gameplay,
+        raycaster,
+        pointerNdc,
+        getGroundHeightAt,
+        getAnchorTarget: getLightGridAnchorTarget,
+        terrainYOffset: TERRAIN_Y_OFFSET,
+    });
+    multiplayerController = createSocketMultiplayer({
+        scene,
+        onStateChange: updateMultiplayerUiState,
+    });
+
+    // Load initial HDR Environment
+    switchEnvironment('sunny-sky');
+
+    // Pedestal
+    const pedestalGeo = new THREE.CylinderGeometry(2.5, 2.5, 0.02, 64);
+    pedestalMat = new THREE.MeshPhysicalMaterial({
+        color: 0xffffff,
+        metalness: 0.1,
+        roughness: 0.05,
+        transmission: 1.0,
+        thickness: 0,
+        ior: 1.0, // IOR 1.0 eliminates double-refraction ghosting from the bottom cap
+        transparent: true,
+        opacity: 0.9 // Slightly more opaque for better grounding
+    });
+    pedestal = new THREE.Mesh(pedestalGeo, pedestalMat);
+    pedestal.position.y = -0.05;
+    scene.add(pedestal);
+
+    worldFloor = createTerrainMesh();
+    scene.add(worldFloor);
+    await applyTerrainTextures(worldFloor);
+    buildLightGrid();
+    rebuildTerrainPhysicsBody();
+
+    grassField = createGrassField({ worldFloor });
+
+    water = createWater({ level: TERRAIN_Y_OFFSET - 0.25 });
+    scene.add(water.mesh);
+
+    // Removed shadow plane to eliminate 'double blur' artifacts
+
+    // Subtle rim
+    const rimGeo = new THREE.TorusGeometry(2.5, 0.02, 16, 100);
+    const rimMat = new THREE.MeshStandardMaterial({ color: 0xEEEEEE, emissive: 0xEEEEEE });
+    const rim = new THREE.Mesh(rimGeo, rimMat);
+    rim.rotation.x = Math.PI / 2;
+    rim.position.y = 0;
+    //scene.add(rim);
+
+    ambientLight = new THREE.AmbientLight(0xffffff, 1.0);
+    scene.add(ambientLight);
+
+    hemiLight = new THREE.HemisphereLight(0xffffff, 0x444444, 1.5);
+    scene.add(hemiLight);
+
+    mainDirectionalLight = new THREE.DirectionalLight(0xffffff, 2.5);
+    mainDirectionalLight.castShadow = true;
+    mainDirectionalLight.shadow.mapSize.width = 4096;
+    mainDirectionalLight.shadow.mapSize.height = 4096;
+    mainDirectionalLight.shadow.camera.near = 0.5;
+    mainDirectionalLight.shadow.camera.far = 60;
+    mainDirectionalLight.shadow.camera.left = -24;
+    mainDirectionalLight.shadow.camera.right = 24;
+    mainDirectionalLight.shadow.camera.top = 24;
+    mainDirectionalLight.shadow.camera.bottom = -24;
+    mainDirectionalLight.shadow.bias = -0.001;
+    mainDirectionalLight.shadow.normalBias = 0.02;
+    scene.add(mainDirectionalLight);
+    scene.add(mainDirectionalLight.target);
+    updateMainDirectionalLightShadowFocus();
+
+    // Create example widgets
+    createExampleWidgets();
+
+    window.addEventListener('resize', onWindowResize);
+
+    // Environment selector
+    const envSelector = document.getElementById('env-selector');
+    if (envSelector) {
+        envSelector.addEventListener('change', (e) => switchEnvironment(e.target.value));
+    }
+
+    // Resolution buttons
+    document.querySelectorAll('.res-btn').forEach(btn => {
+        btn.addEventListener('click', () => setResolution(btn.dataset.res));
+    });
+
+    playHint = document.getElementById('play-hint');
+    gameplayStatus = document.getElementById('gameplay-status');
+    resetViewBtn = document.getElementById('reset-view');
+    if (multiplayerServerUrlInput && !multiplayerServerUrlInput.value.trim()) {
+        multiplayerServerUrlInput.value = getDefaultMultiplayerServerUrl();
+    }
+    if (multiplayerRoomInput && !multiplayerRoomInput.value.trim()) {
+        multiplayerRoomInput.value = multiplayerState.defaultRoom;
+    }
+    multiplayerConnectBtn?.addEventListener('click', () => {
+        multiplayerController?.connect({
+            serverUrl: multiplayerServerUrlInput?.value ?? '',
+            room: multiplayerRoomInput?.value ?? multiplayerState.defaultRoom,
+        });
+    });
+    multiplayerDisconnectBtn?.addEventListener('click', () => {
+        multiplayerController?.disconnect('Disconnected');
+    });
+    updateMultiplayerUiState({
+        statusText: 'Offline',
+        playerCount: 1,
+        connected: false,
+    });
+    updatePropImportStatus();
+    renderImportedPropButtons();
+    initializeMouseActionScripts();
+    setupGameplayEvents();
+    setupTerrainPanel();
+    updateGameplayUI();
+
+    renderer.setAnimationLoop(() => {
+        const delta = Math.min(clock.getDelta(), 0.05);
+
+        const updateStart = performance.now();
+        if (gameplay.active) {
+            updateGameplay(delta);
+        } else {
+            silenceVehicleEngineAudio();
+            updateEngineAudioDebugOverlay('idle', null, null);
+            updateShowcaseCamera(delta);
+        }
+        updateMainDirectionalLightShadowFocus();
+        updateGameplayDebugRay();
+        const updateDuration = performance.now() - updateStart;
+
+        let physicsMetrics = { total: 0, step: 0, sync: 0, collisions: 0 };
+        if (gameplay.active) {
+            physicsMetrics = stepPhysics(delta);
+            updateLitePhysicsPools();
+        }
+        updateVehicleVisuals(delta);
+        updateVehicleSurfaceEffects(delta);
+        syncActorCoreInstances();
+        grassField?.update(delta);
+        water?.update(delta);
+        // Performance toggle: skip the per-frame work entirely when on.
+        // setPerfModeEnabled has already called setEnabled(false) on each subsystem
+        // so visuals stay flat; we just skip the update/tick CPU cost here.
+        if (!perfModeEnabled) {
+            volumetricFogController?.update(delta);
+            postProcessVolumeManager?.update(delta);
+        }
+        const _ddgiStart = performance.now();
+        if (!perfModeEnabled) {
+            getDDGIManager().tick(delta);
+        }
+        const _ddgiMs = performance.now() - _ddgiStart;
+        if (debugConsoleState?.latest) debugConsoleState.latest.ddgi = _ddgiMs;
+        updateObjectAnimations(delta);
+        tickForceAllSceneMeshShadows();
+
+        multiplayerController?.syncLocalSnapshot(getLocalMultiplayerSnapshot());        multiplayerController?.update(delta);
+
+        try {
+            // Update widget system
+            if (widgetManager) {
+                widgetManager.update(delta);
+            }
+
+            const scriptStart = performance.now();
+            runObjectTickScripts(delta);
+            const scriptDuration = performance.now() - scriptStart;
+
+            const renderStart = performance.now();
+            tickRaycastDebugLine();
+            if (postProcessing) {
+                postProcessing.render();
+            } else {
+                renderer.render(scene, camera);
+            }
+
+            recordDebugFrameMetrics({
+                frame: delta * 1000,
+                update: updateDuration,
+                physics: physicsMetrics.total,
+                physicsStep: physicsMetrics.step,
+                physicsSync: physicsMetrics.sync,
+                physicsCollisions: physicsMetrics.collisions,
+                scripts: scriptDuration,
+                render: performance.now() - renderStart,
+                delta,
+            });
+        } catch (e) {
+            console.error('Crash in animation loop:', e);
+            throw e;
+        }
+        updateDebugStatPanels();
+    });
+}
+
+// Render loop now handled by setAnimationLoop in init
+
+function getGroundHitAt(x, z, includeFloor = true, options = {}) {
+    const {
+        ignoreActor = null,
+        targetObjects = null,
+        minSurfaceUpDot = Number.NEGATIVE_INFINITY,
+        surfaceStepTolerance = 0,
+        cullBackFaces = false,
+        maxHitY = Number.POSITIVE_INFINITY,
+    } = options;
+    const originY = Math.max(PLAYER_SETTINGS.probeHeight, gameplayBounds.max.y + PLAYER_SETTINGS.probeHeight);
+    const hits = [];
+
+    raycaster.set(tempVectorA.set(x, originY, z), downVector);
+
+    if (Array.isArray(targetObjects)) {
+        if (targetObjects.length > 0) {
+            hits.push(...raycaster.intersectObjects(targetObjects, true));
+        }
+    } else {
+        if (currentMesh) {
+            hits.push(...raycaster.intersectObject(currentMesh, true));
+        }
+
+        if (sceneSystem?.actors?.size) {
+            for (const actor of sceneSystem.actors) {
+                if (!actor || actor === ignoreActor) continue;
+
+                const actorMesh = getActorRenderObject(actor);
+                if (!actorMesh) continue;
+
+                const actorHits = raycaster.intersectObject(actorMesh, true);
+                if (actorHits.length > 0) {
+                    hits.push(...actorHits);
+                }
+            }
+        }
+    }
+
+    if (includeFloor && worldFloor) {
+        const terrainHeight = sampleTerrainHeightAt(x, z);
+        if (terrainHeight !== null && originY >= terrainHeight) {
+            hits.push({
+                distance: originY - terrainHeight,
+                point: tempVectorB.set(x, terrainHeight, z).clone(),
+                object: worldFloor,
+            });
+        }
+    }
+
+    // Optional strict back-face cull: drop hits whose triangle faces away
+    // from the ray direction (i.e. faces below the trace look down). Used by
+    // car-related ground tracing so a slight overlap between two stitched
+    // road segments can't surface a back-face hit and put the car at the
+    // wrong Y.
+    const backFaceCulledHits = cullBackFaces
+        ? hits.filter((hit) => {
+            if (!hit?.face || !hit.object?.matrixWorld) {
+                return true;
+            }
+            const hitNormal = hit.face.normal.clone().transformDirection(hit.object.matrixWorld);
+            return hitNormal.y > 1e-4;
+        })
+        : hits;
+
+    const heightFilteredHits = Number.isFinite(maxHitY)
+        ? backFaceCulledHits.filter((hit) => (hit?.point?.y ?? Number.NEGATIVE_INFINITY) <= maxHitY)
+        : backFaceCulledHits;
+
+    const filteredHits = minSurfaceUpDot > Number.NEGATIVE_INFINITY
+        ? heightFilteredHits.filter((hit) => {
+            if (!hit?.face || !hit.object?.matrixWorld) {
+                return true;
+            }
+
+            const hitNormal = hit.face.normal.clone().transformDirection(hit.object.matrixWorld);
+            return hitNormal.y >= minSurfaceUpDot;
+        })
+        : heightFilteredHits;
+
+    const resolvedHits = filteredHits.length > 0
+        ? filteredHits
+        : (cullBackFaces ? heightFilteredHits : hits);
+
+    resolvedHits.sort((a, b) => a.distance - b.distance);
+    let resolvedHit = resolvedHits[0] || null;
+    if (resolvedHit && surfaceStepTolerance > 0) {
+        for (let index = 1; index < resolvedHits.length; index += 1) {
+            const candidateHit = resolvedHits[index];
+            if (!candidateHit?.point || !resolvedHit?.point) continue;
+
+            const verticalGap = resolvedHit.point.y - candidateHit.point.y;
+            if (verticalGap > 0 && verticalGap <= surfaceStepTolerance) {
+                resolvedHit = candidateHit;
+                continue;
+            }
+
+            break;
+        }
+    }
+
+    updateRaycasterDebugLine(
+        raycaster.ray,
+        resolvedHit?.distance ?? originY,
+        resolvedHit?.point ?? null,
+        !!resolvedHit,
+    );
+    return resolvedHit;
+}
+
+function getGroundHeightAt(x, z, includeFloor = true, options = {}) {
+    const hit = getGroundHitAt(x, z, includeFloor, options);
+    return hit ? hit.point.y : null;
+}
+
+// --- File Handling ---
+
+// Reads all files from a dropped directory entry recursively, returns filename→{file,url} map
+// --- Optimization Pipeline ---
+// === extracted: textureCompression (was lines 9098-9301 of original main.js) ===
+// Add download listener (using onclick to prevent duplicate listeners on HMR)
+if (downloadBtn) {
+    downloadBtn.onclick = downloadAsset;
+}
+
+// --- Controls ---
+document.getElementById('toggle-wireframe')?.addEventListener('click', () => {
+    if (!currentMesh) return;
+    currentMesh.traverse(child => {
+        if (child.isMesh) child.material.wireframe = !child.material.wireframe;
+    });
+});
+
+document.getElementById('reset-view')?.addEventListener('click', () => {
+    resetShowcaseCamera();
+});
+
+// === UMAP SCENE EXPORT / IMPORT ===
+// === SCENE FOLDER BUNDLE ============================================
+// Folder layout:
+//   <picked-folder>/
+//     scene.umap          (slim — actor records + assetPath references)
+//     assets/
+//       <fileName>.obj    (raw imported source files)
+//
+// Loading any folder bundle is far faster than a legacy .umap because
+// importedTemplates no longer carry rootJson; the OBJ/GLB importer runs
+// against the raw bytes the same way a fresh import does.
+
+// === extracted: sceneSerialization (functions) (was lines 9531-10083 of original main.js) ===
+
+document.getElementById('save-scene-btn')?.addEventListener('click', exportWorldToUmap);
+document.getElementById('load-scene-btn')?.addEventListener('click', () => {
+    document.getElementById('scene-file-input')?.click();
+});
+document.getElementById('scene-file-input')?.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    if (file) {
+        loadWorldFromUmap(file);
+        e.target.value = '';
+    }
+});
+
+document.getElementById('save-scene-folder-btn')?.addEventListener('click', () => {
+    exportWorldToSceneFolder().catch((err) => {
+        console.error('Save Scene Folder failed.', err);
+    });
+});
+document.getElementById('load-scene-folder-btn')?.addEventListener('click', () => {
+    document.getElementById('scene-folder-input')?.click();
+});
+document.getElementById('scene-folder-input')?.addEventListener('change', (e) => {
+    const files = e.target.files;
+    if (files && files.length > 0) {
+        loadWorldFromSceneFolder(files).catch((err) => {
+            console.error('Load Scene Folder failed.', err);
+        });
+        e.target.value = '';
+    }
+});
+
+document.getElementById('load-actor-btn')?.addEventListener('click', () => {
+    document.getElementById('actor-file-input')?.click();
+});
+document.getElementById('actor-file-input')?.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    if (file) {
+        loadActorFromFile(file);
+        e.target.value = '';
+    }
+});
+
+document.getElementById('reset-view')?.addEventListener('click', () => {
+    if (gameplay.active) {
+        respawnPlayer();
+        return;
+    }
+
+    resetShowcaseCamera(true);
+});
+
+// === BLUEPRINT COMPONENT EDITOR ===
+// === extracted: blueprintEditor (block 1) (was lines 10136-10773 of original main.js) ===
+
+document.getElementById('btn-exit-blueprint')?.addEventListener('click', () => {
+    exitBlueprintEditor();
+});
+
+document.getElementById('btn-edit-actor-script')?.addEventListener('click', () => {
+    openObjectScriptEditor('tick');
+});
+
+document.getElementById('btn-bp-apply-physics')?.addEventListener('click', () => {
+    editorHistory.captureState();
+    applyBlueprintPhysicsEditor();
+});
+
+document.getElementById('btn-add-comp-cube')?.addEventListener('click', () => {
+    editorHistory.captureState();
+    const parent = blueprintState.selectedComponent || getActorRenderObject(getDynamicPropById(objectScriptState.targetPropId));
+    if (!parent) return;
+    
+    const mesh = buildPrimitiveActorMesh('cube');
+    mesh.scale.set(0.3, 0.3, 0.3);
+    mesh.position.set(2, 0.5, 0);
+    mesh.material = new THREE.MeshStandardMaterial({ color: 0xff6600, roughness: 0.4, metalness: 0.2 });
+    mesh.name = 'Cube Component';
+    parent.add(mesh);
+    blueprintState.selectedComponent = mesh;
+    blueprintState.selectedComponents.clear();
+    blueprintState.materialMultiSelectActive = false;
+    blueprintState.selectedComponents.add(mesh);
+    if (typeof transformControl !== 'undefined') transformControl.attach(mesh);
+    refreshBlueprintComponents();
+});
+
+document.getElementById('btn-add-comp-sphere')?.addEventListener('click', () => {
+    editorHistory.captureState();
+    const parent = blueprintState.selectedComponent || getActorRenderObject(getDynamicPropById(objectScriptState.targetPropId));
+    if (!parent) return;
+    
+    const mesh = buildPrimitiveActorMesh('sphere');
+    mesh.scale.set(0.3, 0.3, 0.3);
+    mesh.position.set(0, 0.5, 2);
+    mesh.material = new THREE.MeshStandardMaterial({ color: 0x00cc66, roughness: 0.4, metalness: 0.2 });
+    mesh.name = 'Sphere Component';
+    parent.add(mesh);
+    blueprintState.selectedComponent = mesh;
+    blueprintState.selectedComponents.clear();
+    blueprintState.materialMultiSelectActive = false;
+    blueprintState.selectedComponents.add(mesh);
+    if (typeof transformControl !== 'undefined') transformControl.attach(mesh);
+    refreshBlueprintComponents();
+});
+
+document.getElementById('btn-add-comp-collision-box')?.addEventListener('click', () => {
+    editorHistory.captureState();
+    const prop = getDynamicPropById(objectScriptState.targetPropId);
+    const parent = blueprintState.selectedComponent || getActorRenderObject(prop);
+    if (!parent) return;
+
+    const mesh = buildCollisionBoxComponent();
+    mesh.scale.set(0.55, 0.55, 0.55);
+    mesh.position.set(0, 0.75, 0);
+    parent.add(mesh);
+    blueprintState.selectedComponent = mesh;
+    blueprintState.selectedComponents.clear();
+    blueprintState.materialMultiSelectActive = false;
+    if (typeof transformControl !== 'undefined') {
+        transformControl.attach(mesh);
+        transformControl.setMode?.('translate');
+    }
+    if (prop) rebuildActorPhysics(prop);
+    refreshBlueprintComponents();
+});
+
+document.getElementById('btn-add-comp-light')?.addEventListener('click', () => {
+    editorHistory.captureState();
+    const parent = blueprintState.selectedComponent || getActorRenderObject(getDynamicPropById(objectScriptState.targetPropId));
+    if (!parent) return;
+    
+    const light = new THREE.PointLight(0xffddaa, 2, 10);
+    light.position.set(0, 2, 0);
+    light.castShadow = true;
+    light.name = 'Point Light';
+    parent.add(light);
+    blueprintState.selectedComponent = light;
+    blueprintState.selectedComponents.clear();
+    blueprintState.materialMultiSelectActive = false;
+    if (typeof transformControl !== 'undefined') transformControl.attach(light);
+    refreshBlueprintComponents();
+});
+
+document.getElementById('btn-add-comp-spot-light')?.addEventListener('click', () => {
+    editorHistory.captureState();
+    const parent = blueprintState.selectedComponent || getActorRenderObject(getDynamicPropById(objectScriptState.targetPropId));
+    if (!parent) return;
+
+    const light = new THREE.SpotLight(0xfff2cc, 6, 18, Math.PI / 6, 0.35, 2);
+    light.position.set(0, 2, 0);
+    light.castShadow = true;
+    light.shadow.mapSize.set(1024, 1024);
+    light.name = 'Spot Light';
+    light.target.position.set(0, -1.5, 0);
+    light.add(light.target);
+    parent.add(light);
+    blueprintState.selectedComponent = light;
+    blueprintState.selectedComponents.clear();
+    blueprintState.materialMultiSelectActive = false;
+    if (typeof transformControl !== 'undefined') transformControl.attach(light);
+    refreshBlueprintComponents();
+});
+
+document.getElementById('btn-delete-comp')?.addEventListener('click', () => {
+    editorHistory.captureState();
+    const prop = getDynamicPropById(objectScriptState.targetPropId);
+    const rootMesh = getActorRenderObject(prop);
+    const selected = blueprintState.selectedComponent;
+    
+    if (!selected || selected === rootMesh) {
+        alert("Cannot delete the root component!");
+        return;
+    }
+    
+    if (selected.parent) {
+        selected.parent.remove(selected);
+        if (selected.geometry) selected.geometry.dispose();
+        if (selected.material) selected.material.dispose();
+        
+        blueprintState.selectedComponent = rootMesh;
+        blueprintState.selectedComponents.delete(selected);
+        blueprintState.selectedComponents.clear();
+        blueprintState.materialMultiSelectActive = false;
+        if (typeof transformControl !== 'undefined') transformControl.attach(rootMesh);
+        rebuildActorPhysics(prop);
+        refreshBlueprintComponents();
+    }
+});
+
+init().then(() => {
+    applyMobileModeState();
+}).catch((err) => console.error('init failed', err));
+
+// Blueprint Transform Controls
+// === extracted: blueprintEditor (block 2) (was lines 10886-10972 of original main.js) ===
+
+['bp-loc-x', 'bp-loc-y', 'bp-loc-z', 'bp-rot-x', 'bp-rot-y', 'bp-rot-z', 'bp-scl-x', 'bp-scl-y', 'bp-scl-z'].forEach(id => {
+    document.getElementById(id)?.addEventListener('change', () => {
+        applyBlueprintDetailsFromUI();
+        if (blueprintState.active) {
+            const prop = getDynamicPropById(objectScriptState.targetPropId);
+            if (prop) rebuildActorPhysics(prop);
+        }
+    });
+});
+
+// Blueprint panel: Save/Load Actor buttons
+document.getElementById('bp-material-color')?.addEventListener('input', () => {
+    previewBlueprintMaterialEdits();
+});
+document.getElementById('bp-material-emissive')?.addEventListener('input', () => {
+    previewBlueprintMaterialEdits();
+});
+document.getElementById('bp-material-roughness')?.addEventListener('input', () => {
+    syncBlueprintMaterialScalarInput('bp-material-roughness', 'bp-material-roughness-number', 0.5, 0, 1);
+    previewBlueprintMaterialEdits();
+});
+document.getElementById('bp-material-roughness-number')?.addEventListener('change', () => {
+    syncBlueprintMaterialScalarInput('bp-material-roughness-number', 'bp-material-roughness', 0.5, 0, 1);
+    previewBlueprintMaterialEdits();
+});
+document.getElementById('bp-material-metalness')?.addEventListener('input', () => {
+    syncBlueprintMaterialScalarInput('bp-material-metalness', 'bp-material-metalness-number', 0, 0, 1);
+    previewBlueprintMaterialEdits();
+});
+document.getElementById('bp-material-metalness-number')?.addEventListener('change', () => {
+    syncBlueprintMaterialScalarInput('bp-material-metalness-number', 'bp-material-metalness', 0, 0, 1);
+    previewBlueprintMaterialEdits();
+});
+document.getElementById('bp-material-emissive-intensity')?.addEventListener('input', () => {
+    syncBlueprintMaterialScalarInput('bp-material-emissive-intensity', 'bp-material-emissive-intensity-number', 1, 0, 8);
+    previewBlueprintMaterialEdits();
+});
+document.getElementById('bp-material-emissive-intensity-number')?.addEventListener('change', () => {
+    syncBlueprintMaterialScalarInput('bp-material-emissive-intensity-number', 'bp-material-emissive-intensity', 1, 0, 8);
+    previewBlueprintMaterialEdits();
+});
+document.getElementById('bp-material-opacity')?.addEventListener('input', () => {
+    syncBlueprintMaterialScalarInput('bp-material-opacity', 'bp-material-opacity-number', 1, 0, 1);
+    previewBlueprintMaterialEdits();
+});
+document.getElementById('bp-material-opacity-number')?.addEventListener('change', () => {
+    syncBlueprintMaterialScalarInput('bp-material-opacity-number', 'bp-material-opacity', 1, 0, 1);
+    previewBlueprintMaterialEdits();
+});
+document.getElementById('bp-material-alpha-test')?.addEventListener('input', () => {
+    syncBlueprintMaterialScalarInput('bp-material-alpha-test', 'bp-material-alpha-test-number', 0, 0, 1);
+    previewBlueprintMaterialEdits();
+});
+document.getElementById('bp-material-alpha-test-number')?.addEventListener('change', () => {
+    syncBlueprintMaterialScalarInput('bp-material-alpha-test-number', 'bp-material-alpha-test', 0, 0, 1);
+    previewBlueprintMaterialEdits();
+});
+document.getElementById('bp-material-env-intensity')?.addEventListener('input', () => {
+    syncBlueprintMaterialScalarInput('bp-material-env-intensity', 'bp-material-env-intensity-number', 1, 0, 4);
+    previewBlueprintMaterialEdits();
+});
+document.getElementById('bp-material-env-intensity-number')?.addEventListener('change', () => {
+    syncBlueprintMaterialScalarInput('bp-material-env-intensity-number', 'bp-material-env-intensity', 1, 0, 4);
+    previewBlueprintMaterialEdits();
+});
+document.getElementById('bp-material-side')?.addEventListener('change', () => {
+    previewBlueprintMaterialEdits();
+});
+
+document.getElementById('bp-light-color')?.addEventListener('input', () => {
+    applyBlueprintLightEdits({ statusMessage: 'Light color updated.' });
+});
+document.getElementById('bp-light-intensity')?.addEventListener('input', () => {
+    syncBlueprintLightScalarInput('bp-light-intensity', 'bp-light-intensity-number', 1, 0, 20, 1);
+    applyBlueprintLightEdits();
+});
+document.getElementById('bp-light-intensity-number')?.addEventListener('change', () => {
+    syncBlueprintLightScalarInput('bp-light-intensity-number', 'bp-light-intensity', 1, 0, 20, 1);
+    applyBlueprintLightEdits();
+});
+document.getElementById('bp-light-distance')?.addEventListener('input', () => {
+    syncBlueprintLightScalarInput('bp-light-distance', 'bp-light-distance-number', 0, 0, 100, 1);
+    applyBlueprintLightEdits();
+});
+document.getElementById('bp-light-distance-number')?.addEventListener('change', () => {
+    syncBlueprintLightScalarInput('bp-light-distance-number', 'bp-light-distance', 0, 0, 100, 1);
+    applyBlueprintLightEdits();
+});
+document.getElementById('bp-light-decay')?.addEventListener('input', () => {
+    syncBlueprintLightScalarInput('bp-light-decay', 'bp-light-decay-number', 2, 0, 4, 1);
+    applyBlueprintLightEdits();
+});
+document.getElementById('bp-light-decay-number')?.addEventListener('change', () => {
+    syncBlueprintLightScalarInput('bp-light-decay-number', 'bp-light-decay', 2, 0, 4, 1);
+    applyBlueprintLightEdits();
+});
+document.getElementById('bp-light-angle')?.addEventListener('input', () => {
+    syncBlueprintLightScalarInput('bp-light-angle', 'bp-light-angle-number', 30, 1, 120, 0);
+    applyBlueprintLightEdits();
+});
+document.getElementById('bp-light-angle-number')?.addEventListener('change', () => {
+    syncBlueprintLightScalarInput('bp-light-angle-number', 'bp-light-angle', 30, 1, 120, 0);
+    applyBlueprintLightEdits();
+});
+document.getElementById('bp-light-penumbra')?.addEventListener('input', () => {
+    syncBlueprintLightScalarInput('bp-light-penumbra', 'bp-light-penumbra-number', 0, 0, 1, 2);
+    applyBlueprintLightEdits();
+});
+document.getElementById('bp-light-penumbra-number')?.addEventListener('change', () => {
+    syncBlueprintLightScalarInput('bp-light-penumbra-number', 'bp-light-penumbra', 0, 0, 1, 2);
+    applyBlueprintLightEdits();
+});
+['bp-light-target-x', 'bp-light-target-y', 'bp-light-target-z'].forEach((id) => {
+    document.getElementById(id)?.addEventListener('change', () => {
+        applyBlueprintLightEdits({ statusMessage: 'Spot Light target updated.' });
+    });
+});
+document.getElementById('bp-light-cast-shadow')?.addEventListener('change', () => {
+    applyBlueprintLightEdits({ statusMessage: 'Light shadow setting updated.' });
+});
+document.getElementById('btn-bp-apply-material-selected')?.addEventListener('click', () => {
+    applyBlueprintMaterialEdits({ applyToActor: false });
+});
+document.getElementById('btn-bp-apply-material-actor')?.addEventListener('click', () => {
+    applyBlueprintMaterialEdits({ applyToActor: true });
+});
+
+document.getElementById('btn-bp-save-actor')?.addEventListener('click', () => {
+    if (blueprintState.targetActor) {
+        previewBlueprintMaterialEdits();
+        exportActorToFile(blueprintState.targetActor);
+    }
+});
+document.getElementById('btn-bp-load-actor')?.addEventListener('click', () => {
+    document.getElementById('bp-actor-file-input')?.click();
+});
+document.getElementById('bp-actor-file-input')?.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    if (file) {
+        // Exit blueprint mode first, then load
+        exitBlueprintEditor();
+        loadActorFromFile(file);
+        e.target.value = '';
+    }
+});
+
+// === PIE (Play In Editor) Scene State Snapshot ===
+// === extracted: sceneHistory (was lines 11115-11468 of original main.js) ===
+
+
+// =============================================================================
+// Wire extracted modules to engine state (called from init() once globals exist)
+// =============================================================================
+function wireExtractedModules() {
+    bindAppCore({
+        scene: () => scene,
+        camera: () => camera,
+        renderer: () => renderer,
+        currentMesh: () => currentMesh,
+        transformControl: () => transformControl,
+    });
+
+    installAnimatedSample({
+        scene,
+        getCurrentMesh: () => currentMesh,
+        setCurrentMesh: (v) => { currentMesh = v; },
+        getWidgetManager: () => widgetManager,
+        getRuntimeHud,
+        UTextWidget, UProgressBarWidget,
+        clearCurrentMesh, normalizeCurrentMesh, refreshGameplayWorld,
+        updateLoadedAssetStats, enableOptimizationPipeline, playObjectAnimation,
+    });
+
+    installDropHandlers({
+        scene, camera, renderer, container,
+        physics, gameplay,
+        processingOverlay, processingStep, loaderBar,
+        MODEL_TARGET_MAX_DIMENSION,
+        getCurrentMesh: () => currentMesh,
+        setCurrentMesh: (v) => { currentMesh = v; },
+        getModelBody: () => physics.modelBody,
+        setModelBody: (v) => { physics.modelBody = v; },
+        getScanPlane: () => scanPlane,
+        setScanPlane: (v) => { scanPlane = v; },
+        loadObjectFromFile, normalizeObjectToDimension,
+        clearDynamicPhysicsProps, destroyPhysicsBody, destroyPlayerCharacter,
+        disposeRenderableObject, playObjectAnimation,
+        updateLoadedAssetStats, refreshGameplayWorld, updateGameplayUI, exitGameplay,
+    });
+
+    installSceneDebug({
+        scene, camera, renderer, sceneSystem, physics, physicsCore,
+        gameplay, importedPropState,
+        raycastDebugState, collisionDebugState, shadowDebugState,
+        shadowDebugUiRefs, perfModeUiRefs,
+        postProcessVolumeManager,
+        getVolumetricFogController: () => volumetricFogController,
+        getDDGIManager,
+        VEHICLE_SETTINGS,
+        tempVectorC,
+        getActorByBodyId, getActorComponentFlags, getActorRenderObject,
+        physgunCameraRay, pushDebugConsoleLine,
+    });
+
+    installScriptState({
+        physics, gameplay, objectScriptState, debugConsoleState,
+        importedPropState,
+        renderer,
+        objectScriptMenu, objectScriptEditor,
+        OBJECT_SCRIPT_STORAGE_KEY,
+        tempVectorA,
+        copyJoltVector,
+        getDynamicPropById, getActorBody, getActorRenderObject,
+        getMetadataComponent, getScriptComponent, getPhysicsBodyComponent,
+        ensureActorScriptComponent,
+        runObjectEventScript, hasEnabledDynamicPropEvent,
+        closeObjectScriptMenu, closeObjectScriptEditor,
+    });
+
+    installSceneExport({
+        importedPropState,
+        processingOverlay, processingStep, loaderBar, downloadBtn,
+        EXPORT_MAX_TEXTURE_SIZE,
+        getCurrentMesh: () => currentMesh,
+        getSourceFiles: () => sourceFiles,
+        getImportedTemplates: () => importedTemplates,
+        exportWorldToJSON, runWebGPUBenchmark,
+        compressTextures,
+        startScanEffect, stopScanEffect,
+        registerImportedPropTemplateFromSerializedData,
+    });
+
+    installImportedProps({
+        physics, importedPropState,
+        scene, camera,
+        importedPropList, importedPropLibrary,
+        propCollisionPrompt, propCollisionCopy, propCollisionRemember,
+        propImportDefaultStatus, resetPropImportDefaultBtn,
+        IMPORTED_PROP_COLLISION_LABELS, IMPORTED_PROP_COMPLEX_HULL_RADIUS,
+        IMPORTED_PROP_MAX_HULL_PARTS, IMPORTED_PROP_MAX_HULL_POINTS, PROP_TARGET_MAX_DIMENSION,
+        tempVectorA, tempVectorB, tempVectorC, tempVectorD, tempVectorE,
+        cloneDisposableObject, formatImportedPropName, normalizeObjectToDimension,
+        createLoadingManager, convertLoadedObjectMaterials, loadObjectFromFile, processTrigger,
+        createDynamicPropActor, setActorComponentFlags,
+        countTrianglesForObject,
+        createDynamicPrimitiveBody, createStaticMeshBody, createOwnedShape,
+        getDynamicPropSpawn,
+        syncActorEditorTemplateOptions, openActorEditor,
+        disposeRenderableObject, playObjectAnimation,
+        runOptimizationPipeline,
+    });
+
+    installSceneUi({
+        gameplay, blueprintState, objectScriptState, importedPropState,
+        physics, collisionDebugState, mobileState,
+        camera, renderer, scene, sceneSystem,
+        transformControl,
+        actorEditor, actorEditorSummary, actorEditorStatus,
+        actorKindSelect, actorLabelInput, actorScaleInput,
+        actorImportedTemplateSelect, actorVehicleBodyTemplateSelect, actorVehicleWheelTemplateSelect,
+        actorComponentCollisionInput, actorComponentPhysicsInput, actorComponentScriptsInput,
+        actorEditorState,
+        setPendingVehicleTemplateImportSlot: (v) => { pendingVehicleTemplateImportSlot = v; },
+        vehicleTemplateImportInput,
+        postProcessUiRefs, postProcessUiState, postProcessVolumeManager,
+        globalPostProcessUniforms,
+        worldEnvUiRefs, worldEnvState,
+        WORLD_ENV_DEFAULTS, WORLD_ENV_STORAGE_KEY, VEHICLE_CUSTOM_IMPORT_VALUE,
+        sceneUiCount, sceneUiList,
+        getAmbientLight: () => ambientLight,
+        getHemiLight: () => hemiLight,
+        getMainDirectionalLight: () => mainDirectionalLight,
+        getDdgiVolume: () => ddgiVolume,
+        getVolumetricFogController: () => volumetricFogController,
+        getEnvironmentController: () => environmentController,
+        switchEnvironment,
+        getDDGIManager,
+        actorInheritsCore, getActorCoreSource, getActorRenderObject,
+        ensureActorScriptState,
+        selectShowcaseActor, focusSceneActor,
+        enterBlueprintEditor, openObjectScriptEditor,
+        spawnImportedProp, spawnDrivableCar, spawnDynamicPrimitive, spawnDDGIVolumeActor,
+        exportActorToFile,
+        syncBlueprintPhysicsEditor, syncShowcaseAnglesFromTarget, applyShowcaseCameraRotation,
+        refreshCollisionDebugOverlays,
+    });
+
+    installActorPhysics({
+        gameplay, blueprintState, objectScriptState, importedPropState, physics,
+        collisionDebugState, transformControl, actorPhysicsEditorState,
+        getDynamicPropById, getActorSelectionObject, getActorRenderObject,
+        getActorBody, getActorComponentFlags, setActorComponentFlags,
+        findDynamicPropByMesh,
+        buildActorCollisionOverlay, disposeCollisionOverlayObject, refreshCollisionDebugOverlays,
+        createDynamicPrimitiveBody, createStaticMeshBody, createOwnedShape,
+        getPhysicsBodyComponent,
+        refreshSceneUI, refreshBlueprintComponents,
+    });
+
+    installTerrainPanel({
+        terrainBrushState, gameplay, blueprintState,
+        camera, renderer, pointerNdc, raycaster,
+        getWorldFloor: () => worldFloor,
+        getGrassField: () => grassField,
+        applySerializedTerrainState, serializeTerrainState,
+        rebuildTerrainPhysicsBody,
+        applyTerrainSculptBrush,
+        setTerrainCustomImage, setTerrainModeGrassPBR, setTerrainModeGrid, setTerrainModeSolid,
+        setTerrainRepeat, setTerrainRoughness, setTerrainTint,
+        ensurePlayerCharacter, updateWorldPresentation, updateGameplayUI,
+    });
+
+    setupVehicleController({
+        physics, gameplay, vehicleState, importedPropState,
+        camera,
+        VEHICLE_SETTINGS, PLAYER_SETTINGS,
+        getWorldFloor: () => worldFloor,
+        upVector, gameplayLookTarget,
+        tempVectorA, tempVectorB, tempVectorC, tempVectorD, tempVectorE,
+        tempQuaternionA,
+        copyJoltVector, copyJoltQuaternion,
+        getActorBody, getActorRenderObject,
+        emitVehicleSurfaceEffects,
+        getGroundHitAt, getGroundHeightAt,
+        updateGameplayUI, respawnPlayer,
+    });
+
+    setupGameplayLoop({
+        gameplay, physics, showcase, vehicleState, blueprintState, mobileState,
+        terrainBrushState, debugConsoleState, collisionDebugState, importedPropState, objectScriptState,
+        camera, renderer, container,
+        pointerNdc, raycaster, editorHistory, transformControl,
+        gameplayLookTarget, gameplayBounds, mainDirectionalLightShadowFocus, mainDirectionalLightOffset,
+        upVector, tempVectorA, tempVectorB, tempVectorC, tempVectorD, tempVectorE,
+        PLAYER_SETTINGS, VEHICLE_SETTINGS, TERRAIN_Y_OFFSET,
+        SHOWCASE_CAMERA_POSITION, SHOWCASE_CAMERA_TARGET,
+        runtimeAudio,
+        getCurrentMesh: () => currentMesh,
+        getWorldFloor: () => worldFloor,
+        getMainDirectionalLight: () => mainDirectionalLight,
+        getPedestal: () => pedestal,
+        getResetViewBtn: () => resetViewBtn,
+        getGameplayStatus: () => gameplayStatus,
+        getPlayHint: () => playHint,
+        getSceneUiList: () => sceneUiList,
+        setCollisionDebugEnabled,
+        isEditableElement,
+        runMouseAction, applyMouseActionScripts,
+        handleDebugConsoleKeydown,
+        closeObjectScriptMenu, closeObjectScriptEditor, maybeOpenObjectScriptMenuFromMobileTap,
+        isTransformControlSphereHit, handleLightGridClick, focusShowcaseCameraOnObject,
+        selectShowcaseActor, syncTransformControlState,
+        snapshotSceneState, restoreSceneState,
+        updateMouseActionStatus, updateMobileButtons,
+        updateCameraModeButtons, updateBlueprintTransformUI, refreshBlueprintComponents,
+        onWindowResize,
+        getDynamicPropHitFromEvent, getDynamicPropById, getActorRenderObject,
+        applyTerrainBrushFromEvent, updateTerrainBrushPreview,
+        rebuildTerrainPhysicsBody, rebuildModelPhysicsBody, ensurePlayerCharacter, syncCameraToCharacter,
+        copyJoltVector, updateRaycasterDebugLine, positionLightGrid,
+        getGroundHitAt, getGroundHeightAt,
+        spawnDrivableCar,
+        resetAllScriptLifecycleHandles,
+        copySelectedToClipboard, pasteFromClipboard, deleteSelectedActor, duplicateSelected,
+    });
+
+    setupVehicleEngineAudio({
+        scene, camera,
+        vehicleState, vehicleEngineAudio, runtimeAudio, runtimeHud, vehicleFx,
+        engineAudioDebugEl,
+        VEHICLE_SETTINGS, TEST_SOUND_ID,
+        getRuntimeHud, isDrivingVehicle, getActiveVehicleProp,
+        gameplay, objectScriptState, playTestSoundStatus,
+        getDynamicPropById, getActorRenderObject, getActorBody,
+    });
+
+    setupObjectMaterial({
+        getRenderComponent,
+    });
+
+    setupMouseActions({
+        mouseActionState, MouseActionFunction, MOUSE_ACTION_STORAGE_KEY,
+        DEFAULT_MOUSE_ACTION_SCRIPTS, objectScriptState,
+        scene, camera, renderer, currentMesh, gameplay, showcase, physics,
+        sceneSystem, runtimeAudio, getRuntimeHud,
+        playSoundAtLocation, raycastWorld, spawnDynamicPrimitive, spawnImportedProp,
+        spawnDrivableCar, destroyDynamicPhysicsProp,
+        enterGameplay, exitGameplay, respawnPlayer,
+        syncCameraToCharacter, applyGameplayCameraRotation,
+        readObjectScriptDrafts,
+    });
+
+    setupObjectEvents({
+        ObjectEventFunction,
+        objectScriptState, mobileState, gameplay, showcase, physics, runtimeAudio,
+        importedPropState, sceneSystem,
+        objectScriptMenu, objectScriptEditor, objectScriptEditorTitle,
+        objectScriptEditorTarget, objectScriptEditorMode, objectScriptEditorInput,
+        objectScriptEditorStatus, objectScriptEditorApplyBtn,
+        objectScriptEditorClearBtn, objectScriptEditorCancelBtn,
+        objectScriptTickToggleRow, objectScriptTickToggleInput,
+        container,
+        scene, camera, renderer, currentMesh, transformControl,
+        raycaster, pointerNdc, tempVectorA,
+        ensureActorIdentity, ensureObjectScriptDraftEntry, createObjectScriptState,
+        saveObjectScriptDrafts, ensureActorScriptState, getActorScriptState,
+        getActorMetadata, getActorRenderObject, getActorBody, getActorSelectionObject,
+        selectShowcaseActor, syncTransformControlState, rebuildActorPhysics,
+        markActorMaterialDirty, refreshSceneUI, isObjectWithinRoot,
+        disposeRenderableObject, destroyDynamicPhysicsProp, clearDynamicPhysicsProps,
+        runMouseAction, isEditableElement, hasEnabledDynamicPropEvent,
+        playSoundAtLocation, syncRuntimePropIdCounter,
+    });
+
+    setupDebugConsole({
+        debugConsole, debugConsoleOutput, debugConsoleInput, debugConsoleFooter,
+        debugStatsOverlay,
+        debugConsoleState, mobileState, shadowDebugState, raycastDebugState,
+        gameplay, physics,
+        DEBUG_CONSOLE_LOG_LIMIT, DEBUG_CONSOLE_HISTORY_LIMIT,
+        DEBUG_TIMING_SAMPLE_LIMIT,
+        closeObjectScriptMenu, closeObjectScriptEditor, resetMovementInputState,
+        renderer, setRayDebugEnabled, forceAllSceneMeshShadows,
+        setForceAllSceneMeshShadowsEnabled, updateMobileButtons,
+        resetMobileInputState, updateWorldPresentation, updateGameplayUI,
+        isEditableElement,
+    });
+
+    setupMobileControls({
+        mobileState, gameplay, showcase, vehicleState, physics,
+        MOBILE_MOVE_THRESHOLD, MOBILE_MOVE_RADIUS_FACTOR, MOBILE_LOOK_SENSITIVITY,
+        PLAYER_SETTINGS,
+        isDrivingVehicle, setCameraMode, runMouseAction, exitVehicle, enterVehicle,
+        applyGameplayCameraRotation, applyShowcaseCameraRotation,
+    });
+
+    setupSceneSerialization({
+        scene, camera, sceneSystem, physics, importedPropState, objectScriptState,
+        VEHICLE_SETTINGS,
+        getActorBody, getActorRenderObject, getActorScriptState,
+        serializeObjectMaterialState, serializeObjectMaterialOverrides,
+        applyObjectMaterialState, applyObjectMaterialOverrides,
+        serializeImportedPropTemplate, registerImportedPropTemplateFromSerializedData,
+        spawnDrivableCar, spawnImportedProp, spawnDDGIVolumeActor, spawnDynamicPrimitive,
+        syncRuntimePropIdCounter, rebuildActorPhysics, syncPropScriptState,
+        destroyDynamicPhysicsProp, getDynamicPropDisplayName, saveObjectScriptDrafts,
+        refreshSceneUI, selectShowcaseActor, ensureVehicleVisualState,
+        serializeComponentTree, deserializeComponentTree, editorHistory,
+        loadWorldFromJSON,
+    });
+
+    setupBlueprintEditor({
+        scene, camera, transformControl,
+        blueprintState, objectScriptState, sceneSystem,
+        getDynamicPropById, getActorRenderObject, rebuildActorPhysics,
+        refreshSceneUI, selectShowcaseActor, openObjectScriptEditor,
+        applyShowcaseCameraRotation, buildPrimitiveActorMesh,
+        clampMaterialStateValue, getObjectMaterialPreviewState,
+        getObjectMaterialArray, applyObjectMaterialState, editorHistory,
+        showcase, tempVectorA,
+    });
+
+    setupSceneHistory({
+        sceneSystem, scene, transformControl, gameplay, blueprintState,
+        objectScriptState, importedPropState, physics,
+        getDynamicPropById, getActorRenderObject, getActorBody,
+        serializeImportedPropTemplate, registerImportedPropTemplateFromSerializedData,
+        saveObjectScriptDrafts, refreshSceneUI, selectShowcaseActor,
+        buildPrimitiveActorMesh, applyObjectMaterialState, serializeObjectMaterialState,
+        enterBlueprintEditor, exitBlueprintEditor, refreshBlueprintComponents,
+        serializeWorldTerrainState, applyWorldTerrainState, refreshGameplayWorld,
+        forceExitGameplayForWorldLoad, updateGameplayUI, updateWorldPresentation,
+    });
+}
+

--- a/src/optim/sceneExport.js
+++ b/src/optim/sceneExport.js
@@ -1,0 +1,334 @@
+// src/optim/sceneExport.js
+// Extracted from main.js (chore/main-js-shrink-2). Owns the optimization +
+// scene-export pipeline: GLTFExporter glue, meshopt simplification, OBJ-style
+// folder export, and the WebGPU benchmark run that gates the pipeline.
+
+import * as THREE from 'three';
+import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
+import { MeshoptSimplifier } from 'meshoptimizer';
+import gsap from 'gsap';
+
+let importedPropState;
+let processingOverlay, processingStep, loaderBar;
+let downloadBtn;
+let EXPORT_MAX_TEXTURE_SIZE;
+let getCurrentMesh, getSourceFiles, getImportedTemplates;
+let exportWorldToJSON, runWebGPUBenchmark;
+let compressTextures;
+let startScanEffect, stopScanEffect;
+let registerImportedPropTemplateFromSerializedData;
+
+export function installSceneExport(deps) {
+    ({
+        importedPropState,
+        processingOverlay, processingStep, loaderBar, downloadBtn,
+        EXPORT_MAX_TEXTURE_SIZE,
+        getCurrentMesh, getSourceFiles, getImportedTemplates,
+        exportWorldToJSON, runWebGPUBenchmark,
+        compressTextures,
+        startScanEffect, stopScanEffect,
+        registerImportedPropTemplateFromSerializedData,
+    } = deps);
+}
+
+export async function runOptimizationPipeline() {
+    processingOverlay.style.display = 'flex';
+    const isPro = false;
+
+    // --- Analytics Pixel Tracking ---
+    // Simple privacy-first ping to track how many users actually run the pipeline.
+    // Replace with your actual analytics tracking pixel URL (e.g. Plausible, SimpleAnalytics, or custom).
+    try {
+        new Image().src = `https://your-analytics-domain.com/pixel.gif?event=run_pipeline&isPro=${isPro}&ts=${Date.now()}`;
+        console.log('Analytics ping sent: run_pipeline');
+    } catch (e) {
+        /* Ignore analytics errors so it doesn't block the UI */
+    }
+
+    const steps = [
+        { label: 'Initializing WebGPU kernels...', progress: 10 },
+        { label: 'Analyzing mesh topology...', progress: 20 },
+        { label: 'Executing Parallel Decimation...', progress: 45 },
+        { label: isPro ? 'Optimizing PBR textures (KTX2 + BasisU)...' : 'Optimizing PBR textures (WebP)...', progress: 75 },
+        { label: 'Baking PBR texture maps...', progress: 85 },
+        { label: 'Exporting optimized GLB...', progress: 100 }
+    ];
+
+    for (const step of steps) {
+        processingStep.textContent = step.label;
+        if (step.label.includes('Decimation')) {
+            startScanEffect();
+        }
+        await gsap.to(loaderBar, { width: `${step.progress}%`, duration: 0.8 });
+        await new Promise(r => setTimeout(r, 400));
+    }
+
+    try {
+        // Run WebGPU Benchmark for UI "Wow" factor
+        const benchmark = await runWebGPUBenchmark(originalTriCount * 3);
+        if (benchmark) {
+            document.getElementById('webgpu-speedup').textContent = `${benchmark.speedup.toFixed(1)}x`;
+        }
+
+        // Actual Simplification
+        const ratio = parseFloat(document.getElementById('ratio-slider').value);
+        simplifyMesh(ratio);
+
+        // Best current in-browser path: aggressive texture recompression + smaller export textures.
+        await compressTextures(getCurrentMesh(), 0.8, EXPORT_MAX_TEXTURE_SIZE, isPro);
+
+        // Export to get real size
+        const exporter = new GLTFExporter();
+        const gltfData = await new Promise((resolve, reject) => {
+            exporter.parse(getCurrentMesh(), resolve, reject, {
+                binary: true,
+                maxTextureSize: EXPORT_MAX_TEXTURE_SIZE,
+                onlyVisible: true,
+            });
+        });
+
+        const blob = new Blob([gltfData], { type: 'application/octet-stream' });
+        if (optimizedBlobUrl) URL.revokeObjectURL(optimizedBlobUrl);
+        optimizedBlobUrl = URL.createObjectURL(blob);
+
+        const optimizedSize = blob.size;
+        document.getElementById('file-size').textContent = (optimizedSize / (1024 * 1024)).toFixed(1) + ' MB';
+        document.getElementById('file-diff').textContent = `(-${Math.round((1 - (optimizedSize / originalFileSize)) * 100)}%)`;
+
+        processingOverlay.style.display = 'none';
+        downloadBtn.style.display = 'flex';
+    } catch (err) {
+        console.error('Optimization failed:', err);
+        alert('Optimization failed. Check console for details.');
+        processingOverlay.style.display = 'none';
+        stopScanEffect();
+    }
+}
+
+export function simplifyMesh(ratio = 0.12) {
+    if (!getCurrentMesh()) return;
+
+    stopScanEffect();
+
+    let totalReducedTris = 0;
+
+    getCurrentMesh().traverse((child) => {
+        if (child.isMesh) {
+            const geometry = child.geometry.clone();
+            const positions = geometry.attributes.position.array;
+            let indices = geometry.index ? geometry.index.array : null;
+
+            if (!indices) {
+                // If no index, create one (meshoptimizer needs indices)
+                const count = positions.length / 3;
+                indices = new Uint32Array(count);
+                for (let i = 0; i < count; i++) indices[i] = i;
+            } else if (!(indices instanceof Uint32Array)) {
+                indices = new Uint32Array(indices);
+            }
+
+            const targetCount = Math.floor((indices.length / 3) * ratio) * 3;
+            const targetError = 0.01;
+
+            const [simplifiedIndices, error] = MeshoptSimplifier.simplify(
+                indices,
+                positions,
+                3,
+                targetCount,
+                targetError
+            );
+
+            geometry.setIndex(new THREE.BufferAttribute(simplifiedIndices, 1));
+            child.geometry = geometry;
+
+            totalReducedTris += simplifiedIndices.length / 3;
+
+            // Visual feedback: briefly show wireframe
+            child.material.wireframe = true;
+            setTimeout(() => { child.material.wireframe = false; }, 1000);
+        }
+    });
+
+    optimizedTriCount = Math.round(totalReducedTris);
+    document.getElementById('tri-diff').textContent = `(-${Math.round((1 - (optimizedTriCount / originalTriCount)) * 100)}%)`;
+
+    const countObj = { val: originalTriCount };
+    gsap.to(countObj, {
+        val: optimizedTriCount,
+        duration: 1.5,
+        ease: "power2.out",
+        onUpdate: () => {
+            document.getElementById('tri-count').textContent = Math.ceil(countObj.val).toLocaleString();
+        }
+    });
+}
+
+export function downloadAsset() {
+    if (!optimizedBlobUrl) return;
+
+    const a = document.createElement('a');
+    a.href = optimizedBlobUrl;
+
+    let baseName = document.getElementById('asset-name').textContent;
+    baseName = baseName.replace(/\.[^/.]+$/, ""); // Remove extension if exists
+    a.download = `optimized_${baseName}.glb`;
+
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+}
+
+export function exportWorldToUmap() {
+    const umap = exportWorldToJSON();
+    const blob = new Blob([JSON.stringify(umap, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'scene.umap';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 100);
+}
+
+export async function exportWorldToSceneFolder() {
+    const umap = exportWorldToJSON({ preferAssetPath: true });
+    const vehicleTemplateIds = new Set();
+    for (const actor of umap.actors || []) {
+        if (actor?.kind !== 'vehicle') continue;
+        if (actor.vehicleBodyTemplateId) vehicleTemplateIds.add(actor.vehicleBodyTemplateId);
+        if (actor.vehicleWheelTemplateId) vehicleTemplateIds.add(actor.vehicleWheelTemplateId);
+    }
+
+    // Build a parallel GLB cache for every imported template referenced by the
+    // bundle. GLB parses ~10x faster than text OBJ for huge models (e.g. a
+    // 300 MB car), so on next load registerImportedPropTemplateFromSerializedData
+    // can skip the OBJ path entirely. Fall back to the raw source file for any
+    // template whose GLB export fails.
+    const glbAssets = new Map(); // templateId -> { fileName, blob }
+    const rawFiles = new Map();  // templateId -> File (fallback only)
+
+    for (const t of umap.importedTemplates || []) {
+        const template = importedPropState.templates.find((entry) => entry.id === t.id);
+        if (!template?.root) continue;
+        const sourceFile = importedPropState.sourceFiles[t.id];
+
+        if (vehicleTemplateIds.has(t.id) && sourceFile) {
+            rawFiles.set(t.id, sourceFile);
+            t.assetPath = `assets/${sourceFile.name}`;
+            t.assetType = 'raw';
+            delete t.rootJson;
+            continue;
+        }
+
+        try {
+            const glbBlob = await exportRootToGlb(template.root);
+            const glbName = `${t.id}.glb`;
+            glbAssets.set(t.id, { fileName: glbName, blob: glbBlob });
+            t.assetPath = `assets/${glbName}`;
+            t.assetType = 'glb';
+        } catch (err) {
+            console.warn(`[scene] GLB export failed for template ${t.id}; falling back to raw source.`, err);
+            if (sourceFile) {
+                rawFiles.set(t.id, sourceFile);
+                t.assetPath = `assets/${sourceFile.name}`;
+                t.assetType = 'raw';
+            } else {
+                // No GLB and no raw file — re-inline rootJson so this template
+                // still loads (slower but correct).
+                delete t.assetPath;
+                delete t.assetType;
+                t.rootJson = template.root.toJSON();
+            }
+        }
+    }
+
+    const useFsAccess = typeof window !== 'undefined' && typeof window.showDirectoryPicker === 'function';
+    if (useFsAccess) {
+        let dirHandle;
+        try {
+            dirHandle = await window.showDirectoryPicker({ mode: 'readwrite' });
+        } catch (err) {
+            if (err?.name === 'AbortError') return;
+            console.error('Folder picker failed; falling back to multi-file download.', err);
+            return downloadSceneFolderFallback(umap, glbAssets, rawFiles);
+        }
+        try {
+            await writeFileToDirectory(dirHandle, 'scene.umap', JSON.stringify(umap, null, 2));
+            if (glbAssets.size > 0 || rawFiles.size > 0) {
+                const assetsDir = await dirHandle.getDirectoryHandle('assets', { create: true });
+                for (const { fileName, blob } of glbAssets.values()) {
+                    await writeFileToDirectory(assetsDir, fileName, blob);
+                }
+                for (const file of rawFiles.values()) {
+                    await writeFileToDirectory(assetsDir, file.name, file);
+                }
+            }
+            console.info('[scene] Saved scene folder to picked directory.');
+        } catch (err) {
+            console.error('Failed to write scene folder.', err);
+            alert('Failed to write scene folder. See console for details.');
+        }
+        return;
+    }
+
+    // Fallback for browsers without File System Access API: drop separate
+    // downloads. The user reassembles the folder manually.
+    downloadSceneFolderFallback(umap, glbAssets, rawFiles);
+}
+
+export function exportRootToGlb(root) {
+    return new Promise((resolve, reject) => {
+        const exporter = new GLTFExporter();
+        exporter.parse(
+            root,
+            (result) => {
+                if (result instanceof ArrayBuffer) {
+                    resolve(new Blob([result], { type: 'model/gltf-binary' }));
+                } else {
+                    // Defensive: caller asked for binary, but if a runtime
+                    // returns JSON anyway, ship it as a non-binary GLB blob.
+                    resolve(new Blob([JSON.stringify(result)], { type: 'model/gltf+json' }));
+                }
+            },
+            reject,
+            { binary: true, onlyVisible: false }
+        );
+    });
+}
+
+export async function writeFileToDirectory(dirHandle, name, contents) {
+    const fileHandle = await dirHandle.getFileHandle(name, { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(contents);
+    await writable.close();
+}
+
+export function downloadSceneFolderFallback(umap, glbAssets, rawFiles) {
+    const triggerDownload = (blob, name) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = name;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        setTimeout(() => URL.revokeObjectURL(url), 100);
+    };
+
+    triggerDownload(
+        new Blob([JSON.stringify(umap, null, 2)], { type: 'application/json' }),
+        'scene.umap'
+    );
+    if (glbAssets) {
+        for (const { fileName, blob } of glbAssets.values()) {
+            triggerDownload(blob, fileName);
+        }
+    }
+    if (rawFiles) {
+        for (const file of rawFiles.values()) {
+            triggerDownload(file, file.name);
+        }
+    }
+    alert('Saved scene.umap and its assets as separate downloads. Place them in a folder with assets/<file> next to scene.umap before loading.');
+}

--- a/src/physics/actorPhysics.js
+++ b/src/physics/actorPhysics.js
@@ -1,0 +1,378 @@
+// src/physics/actorPhysics.js
+// Extracted from main.js (chore/main-js-shrink-2). Owns rebuildActorPhysics,
+// the per-actor physics inputs (mass / friction / restitution preview) and the
+// gizmo↔body sync helpers (syncTransformControlState, syncTransformToPhysics,
+// applyBlueprintPhysicsEditor). All Jolt construction helpers + the actor
+// metadata helpers stay in main.js and come through as deps.
+
+import * as THREE from 'three';
+
+let gameplay, blueprintState, objectScriptState, importedPropState, physics;
+let collisionDebugState, transformControl, actorPhysicsEditorState;
+let getDynamicPropById, getActorSelectionObject, getActorRenderObject;
+let getActorBody, getActorComponentFlags, setActorComponentFlags;
+let findDynamicPropByMesh;
+let buildActorCollisionOverlay, disposeCollisionOverlayObject, refreshCollisionDebugOverlays;
+let createDynamicPrimitiveBody, createStaticMeshBody, createOwnedShape;
+let getPhysicsBodyComponent;
+let refreshSceneUI, refreshBlueprintComponents;
+
+export function installActorPhysics(deps) {
+    ({
+        gameplay, blueprintState, objectScriptState, importedPropState, physics,
+        collisionDebugState, transformControl, actorPhysicsEditorState,
+        getDynamicPropById, getActorSelectionObject, getActorRenderObject,
+        getActorBody, getActorComponentFlags, setActorComponentFlags,
+        findDynamicPropByMesh,
+        buildActorCollisionOverlay, disposeCollisionOverlayObject, refreshCollisionDebugOverlays,
+        createDynamicPrimitiveBody, createStaticMeshBody, createOwnedShape,
+        getPhysicsBodyComponent,
+        refreshSceneUI, refreshBlueprintComponents,
+    } = deps);
+}
+
+export function syncTransformControlState() {
+    if (!transformControl) return;
+
+    const helper = transformControl.getHelper?.() ?? null;
+    const shouldEnable = !gameplay.active && !gameplay.pointerLocked;
+
+    transformControl.enabled = shouldEnable;
+    if (helper) {
+        helper.visible = shouldEnable && !!transformControl.object;
+    }
+
+    if (!shouldEnable) {
+        transformControl.detach();
+        return;
+    }
+
+    if (transformControl.object || blueprintState.active) {
+        if (helper) helper.visible = !!transformControl.object;
+        return;
+    }
+
+    const selectedActor = getDynamicPropById(objectScriptState.targetPropId);
+    const selectedMesh = getActorSelectionObject(selectedActor);
+    if (selectedMesh) {
+        transformControl.attach(selectedMesh);
+        if (helper) helper.visible = true;
+    }
+}
+
+export function syncTransformToPhysics() {
+    if (!transformControl || !transformControl.object) return;
+    
+    // In blueprint mode, child components can be moved freely without physics sync
+    if (blueprintState.active) return;
+    
+    const prop = findDynamicPropByMesh(transformControl.object);
+    if (!prop) return;
+
+    const body = getActorBody(prop);
+    if (!body || !physics.jolt) return;
+
+    const mesh = transformControl.object;
+    const rootMesh = getActorRenderObject(prop);
+    if (mesh !== rootMesh) {
+        rebuildActorPhysics(prop);
+        return;
+    }
+
+    const pos = mesh.position;
+    const rot = mesh.quaternion;
+
+    const { bodyInterface, Jolt } = physics;
+    
+    // Position and Rotation sync
+    const joltPos = new Jolt.Vec3(pos.x, pos.y, pos.z);
+    const joltRot = new Jolt.Quat(rot.x, rot.y, rot.z, rot.w);
+    bodyInterface.SetPositionAndRotation(body.GetID(), joltPos, joltRot, Jolt.EActivation_Activate);
+    Jolt.destroy(joltPos);
+    Jolt.destroy(joltRot);
+    
+    // Scale sync (requires rebuilding the body for primitives)
+    if (transformControl.getMode() === 'scale') {
+        rebuildActorPhysics(prop);
+    }
+}
+
+export function rebuildActorPhysics(prop) {
+    if (!prop || !getActorRenderObject(prop) || !physics.ready) return;
+    
+    const { Jolt, bodyInterface } = physics;
+    const componentFlags = getActorComponentFlags(prop);
+    const currentBody = getActorBody(prop);
+    const bodyID = currentBody?.GetID();
+    const dynamicIndex = physics.dynamicBodies.indexOf(prop);
+    const staticIndex = physics.staticBodies.indexOf(prop);
+    
+    if (bodyID) {
+        bodyInterface.RemoveBody(bodyID);
+        bodyInterface.DestroyBody(bodyID);
+    }
+    prop.body = null;
+    const physicsBodyComponent = getPhysicsBodyComponent(prop);
+    if (physicsBodyComponent) {
+        physicsBodyComponent.body = null;
+    }
+    if (dynamicIndex >= 0) physics.dynamicBodies.splice(dynamicIndex, 1);
+    if (staticIndex >= 0) physics.staticBodies.splice(staticIndex, 1);
+
+    if (!componentFlags.collision) {
+        return;
+    }
+    
+    const importedTemplate = prop.kind === 'imported'
+        ? importedPropState.templates.find((entry) => entry.id === prop.templateId)
+        : null;
+    const useExactMeshCollision = importedTemplate?.collisionMode === 'complex';
+
+    let bodyOptions = {
+        rotation: getActorRenderObject(prop).quaternion,
+        mass: prop.userData?.physicsMass,
+        friction: prop.userData?.physicsFriction ?? prop.userData?.friction ?? 0.5,
+        restitution: prop.userData?.physicsRestitution ?? prop.userData?.restitution ?? 0.3,
+        allowedDOFs: prop.userData?.allowedDOFs,
+        kinematic: prop.userData?.kinematic,
+        simulatePhysics: useExactMeshCollision ? false : componentFlags.physics,
+        activate: true
+    };
+    
+    const rootMesh = getActorRenderObject(prop);
+    rootMesh.updateMatrixWorld(true);
+
+    if (useExactMeshCollision) {
+        const newBody = createStaticMeshBody(rootMesh, bodyOptions);
+        prop.body = newBody;
+        if (physicsBodyComponent) physicsBodyComponent.body = newBody;
+        setActorComponentFlags(prop, {
+            ...componentFlags,
+            collision: !!newBody,
+            physics: false,
+        });
+        if (newBody) physics.staticBodies.push(prop);
+        if (actorPhysicsEditorState.previewActorId === prop.id) refreshActorPhysicsPreview();
+        return;
+    }
+
+    const subShapes = [];
+    const compoundSettings = new Jolt.MutableCompoundShapeSettings();
+    let hasCompound = false;
+    let hasExplicitCollisionShapes = false;
+    rootMesh.traverse((node) => {
+        if (node.userData?.isCollisionShape) hasExplicitCollisionShapes = true;
+    });
+
+    // A helper to traverse and collect collision shapes
+    function traverseAndBuildShapes(node, isRoot) {
+        const isCollisionShape = !!node.userData?.isCollisionShape;
+        if (!node.visible && !isCollisionShape) return; // Skip hidden visual components
+        if (hasExplicitCollisionShapes && !isCollisionShape) {
+            for (const child of node.children) {
+                traverseAndBuildShapes(child, false);
+            }
+            return;
+        }
+        
+        // Handle only meshes
+        if (node.isMesh) {
+            let shapeSetting = null;
+            const geo = node.geometry;
+            const scale = node.scale;
+            
+            // For primitive meshes created via UI
+            if (geo?.type === 'SphereGeometry') {
+                shapeSetting = new Jolt.SphereShapeSettings(scale.x);
+            } else if (geo?.type === 'BoxGeometry') {
+                const halfExtents = new Jolt.Vec3(scale.x, scale.y, scale.z);
+                shapeSetting = new Jolt.BoxShapeSettings(halfExtents, 0.05);
+                Jolt.destroy(halfExtents);
+            } else if (geo?.type === 'CapsuleGeometry') {
+                shapeSetting = new Jolt.CapsuleShapeSettings(scale.y, scale.x);
+            } else if (isRoot && prop.kind === 'sphere') {
+                shapeSetting = new Jolt.SphereShapeSettings(scale.x);
+            } else if (isRoot && prop.kind === 'cube') {
+                const halfExtents = new Jolt.Vec3(scale.x, scale.y, scale.z);
+                shapeSetting = new Jolt.BoxShapeSettings(halfExtents, 0.05);
+                Jolt.destroy(halfExtents);
+            } else if (isRoot && prop.kind === 'capsule') {
+                shapeSetting = new Jolt.CapsuleShapeSettings(scale.y, scale.x);
+            } else if (!isRoot) {
+                // Treat imported nested child geometries as boxes for simplicity if type is unknown
+                const bbox = new THREE.Box3().setFromObject(node, true);
+                if (!bbox.isEmpty()) {
+                    const size = new THREE.Vector3();
+                    bbox.getSize(size);
+                    const halfExtents = new Jolt.Vec3(Math.max(size.x/2, 0.05), Math.max(size.y/2, 0.05), Math.max(size.z/2, 0.05));
+                    shapeSetting = new Jolt.BoxShapeSettings(halfExtents, 0.05);
+                    Jolt.destroy(halfExtents);
+                }
+            }
+            
+            if (shapeSetting) {
+                const subShape = createOwnedShape(shapeSetting);
+                subShapes.push(subShape);
+                
+                // Calculate relative position/rotation to the root
+                const pos = new Jolt.Vec3(node.position.x, node.position.y, node.position.z);
+                const rot = new Jolt.Quat(node.quaternion.x, node.quaternion.y, node.quaternion.z, node.quaternion.w);
+                
+                compoundSettings.AddShapeShape(pos, rot, subShape, 0);
+                Jolt.destroy(pos);
+                Jolt.destroy(rot);
+                hasCompound = true;
+            }
+        }
+        
+        for (const child of node.children) {
+            traverseAndBuildShapes(child, false);
+        }
+    }
+    
+    traverseAndBuildShapes(rootMesh, true);
+    
+    let finalShape = null;
+    
+    if (hasCompound) {
+        if (subShapes.length === 1 && rootMesh.children.length === 0) {
+            // Optimization: if it's just the root shape and no children, use it directly
+            finalShape = subShapes[0];
+            Jolt.destroy(compoundSettings); // We don't need the compound wrapper
+        } else {
+            // We have multiple components or child transforms
+            finalShape = createOwnedShape(compoundSettings);
+        }
+    } else {
+        Jolt.destroy(compoundSettings);
+    }
+    
+    if (finalShape) {
+        const newBody = createDynamicPrimitiveBody(finalShape, rootMesh.position, null, bodyOptions);
+        prop.body = newBody;
+        if (physicsBodyComponent) physicsBodyComponent.body = newBody;
+        setActorComponentFlags(prop, {
+            ...componentFlags,
+            collision: !!newBody,
+            physics: !!newBody && componentFlags.physics,
+        });
+        if (newBody) {
+            if (componentFlags.physics) {
+                physics.dynamicBodies.push(prop);
+            } else {
+                physics.staticBodies.push(prop);
+            }
+        }
+    }
+    if (actorPhysicsEditorState.previewActorId === prop.id) refreshActorPhysicsPreview();
+}
+
+export function buildCollisionBoxComponent() {
+    const mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(2, 2, 2),
+        new THREE.MeshBasicMaterial({
+            color: 0x22d3ee,
+            transparent: true,
+            opacity: 0.16,
+            wireframe: true,
+            depthTest: false,
+        })
+    );
+    mesh.name = 'Collision Box';
+    mesh.renderOrder = 20;
+    mesh.userData.isCollisionShape = true;
+    mesh.userData.collisionShapeType = 'box';
+    mesh.userData.skipMaterialExport = true;
+    return mesh;
+}
+
+export function getActorPhysicsSettings(actor) {
+    const userData = actor?.userData ?? {};
+    return {
+        mass: Number.isFinite(userData.physicsMass) ? userData.physicsMass : 12,
+        friction: Number.isFinite(userData.physicsFriction) ? userData.physicsFriction : (Number.isFinite(userData.friction) ? userData.friction : 0.5),
+        restitution: Number.isFinite(userData.physicsRestitution) ? userData.physicsRestitution : (Number.isFinite(userData.restitution) ? userData.restitution : 0.3),
+    };
+}
+
+export function clearActorPhysicsPreview() {
+    const overlay = actorPhysicsEditorState.previewOverlay;
+    if (overlay) {
+        overlay.parent?.remove(overlay);
+        disposeCollisionOverlayObject(overlay);
+    }
+    actorPhysicsEditorState.previewOverlay = null;
+    actorPhysicsEditorState.previewActorId = '';
+}
+
+export function refreshActorPhysicsPreview() {
+    const actorId = actorPhysicsEditorState.previewActorId;
+    if (!actorId) return;
+
+    const actor = getDynamicPropById(actorId);
+    const actorMesh = getActorRenderObject(actor);
+    const nextOverlay = actor ? buildActorCollisionOverlay(actor) : null;
+
+    if (actorPhysicsEditorState.previewOverlay) {
+        actorPhysicsEditorState.previewOverlay.parent?.remove(actorPhysicsEditorState.previewOverlay);
+        disposeCollisionOverlayObject(actorPhysicsEditorState.previewOverlay);
+        actorPhysicsEditorState.previewOverlay = null;
+    }
+
+    if (!actorMesh || !nextOverlay) {
+        actorPhysicsEditorState.previewActorId = '';
+        return;
+    }
+
+    nextOverlay.name = 'actor-physics-preview-overlay';
+    actorMesh.add(nextOverlay);
+    actorPhysicsEditorState.previewOverlay = nextOverlay;
+}
+
+export function setActorPhysicsPreview(actor, enabled) {
+    clearActorPhysicsPreview();
+    if (!enabled || !actor?.id) return;
+    actorPhysicsEditorState.previewActorId = actor.id;
+    refreshActorPhysicsPreview();
+}
+
+export function applyActorPhysicsSettings(actor, settings) {
+    if (!actor) return;
+
+    const next = {
+        physicsMass: THREE.MathUtils.clamp(Number(settings.mass) || 12, 0.01, 100000),
+        physicsFriction: THREE.MathUtils.clamp(Number(settings.friction) || 0, 0, 2),
+        physicsRestitution: THREE.MathUtils.clamp(Number(settings.restitution) || 0, 0, 1),
+    };
+    Object.assign(actor.userData, next);
+    const mesh = getActorRenderObject(actor);
+    if (mesh?.userData) Object.assign(mesh.userData, next);
+
+    if (getActorComponentFlags(actor).collision) {
+        rebuildActorPhysics(actor);
+    }
+    refreshActorPhysicsPreview();
+    if (collisionDebugState.enabled) refreshCollisionDebugOverlays();
+    refreshSceneUI();
+}
+
+export function syncBlueprintPhysicsEditor(actor = getDynamicPropById(objectScriptState.targetPropId)) {
+    const settings = getActorPhysicsSettings(actor);
+    const mass = document.getElementById('bp-physics-mass');
+    const friction = document.getElementById('bp-physics-friction');
+    const restitution = document.getElementById('bp-physics-restitution');
+    if (mass) mass.value = String(settings.mass);
+    if (friction) friction.value = String(settings.friction);
+    if (restitution) restitution.value = String(settings.restitution);
+}
+
+export function applyBlueprintPhysicsEditor() {
+    const actor = getDynamicPropById(objectScriptState.targetPropId);
+    if (!actor) return;
+    applyActorPhysicsSettings(actor, {
+        mass: parseFloat(document.getElementById('bp-physics-mass')?.value ?? '12'),
+        friction: parseFloat(document.getElementById('bp-physics-friction')?.value ?? '0.5'),
+        restitution: parseFloat(document.getElementById('bp-physics-restitution')?.value ?? '0.3'),
+    });
+    refreshBlueprintComponents();
+}

--- a/src/scripting/scriptState.js
+++ b/src/scripting/scriptState.js
@@ -331,3 +331,33 @@ export function updateDynamicBodyCollisionScripts() {
 
         scriptState.activeCollisions = new Set(nextCollisions.keys());
     });
+}
+
+export function handleObjectScriptGlobalPointerDown(event) {
+    const clickedInsideMenu = objectScriptMenu && !objectScriptMenu.hidden && objectScriptMenu.contains(event.target);
+    const clickedInsideEditor = objectScriptEditor && !objectScriptEditor.hidden && objectScriptEditor.contains(event.target);
+
+    if (!clickedInsideMenu && objectScriptState.menuOpen) {
+        closeObjectScriptMenu();
+    }
+
+    if (!clickedInsideEditor && objectScriptState.editorOpen && event.target !== renderer?.domElement) {
+        closeObjectScriptEditor();
+    }
+}
+
+export function handleObjectScriptKeydown(event) {
+    if (event.key !== 'Escape') return;
+
+    if (debugConsoleState.visible) {
+        return;
+    }
+
+    if (objectScriptState.menuOpen) {
+        closeObjectScriptMenu();
+    }
+
+    if (objectScriptState.editorOpen) {
+        closeObjectScriptEditor();
+    }
+}

--- a/src/scripting/scriptState.js
+++ b/src/scripting/scriptState.js
@@ -1,0 +1,333 @@
+// src/scripting/scriptState.js
+// Extracted from main.js (chore/main-js-shrink-2). Owns:
+//   - script-state primitives (createObjectScriptState, draft sanitize/read/save)
+//   - actor identity / metadata helpers (ensureActorIdentity, getActorMetadata,
+//     getActorScriptState, ensureActorScriptState)
+//   - runtime prop-id counters
+//   - per-frame collision-script driver (updateDynamicBodyCollisionScripts)
+//   - object-script editor pointerdown/keydown plumbing.
+
+import * as THREE from 'three';
+
+let physics, gameplay, objectScriptState, debugConsoleState;
+let importedPropState;
+let renderer;
+let objectScriptMenu, objectScriptEditor;
+let OBJECT_SCRIPT_STORAGE_KEY;
+let tempVectorA;
+let copyJoltVector;
+let getDynamicPropById, getActorBody, getActorRenderObject;
+let getMetadataComponent, getScriptComponent, getPhysicsBodyComponent;
+let ensureActorScriptComponent;
+let runObjectEventScript, hasEnabledDynamicPropEvent;
+let closeObjectScriptMenu, closeObjectScriptEditor;
+
+export function installScriptState(deps) {
+    ({
+        physics, gameplay, objectScriptState, debugConsoleState,
+        importedPropState,
+        renderer,
+        objectScriptMenu, objectScriptEditor,
+        OBJECT_SCRIPT_STORAGE_KEY,
+        tempVectorA,
+        copyJoltVector,
+        getDynamicPropById, getActorBody, getActorRenderObject,
+        getMetadataComponent, getScriptComponent, getPhysicsBodyComponent,
+        ensureActorScriptComponent,
+        runObjectEventScript, hasEnabledDynamicPropEvent,
+        closeObjectScriptMenu, closeObjectScriptEditor,
+    } = deps);
+}
+
+export function createDefaultObjectEventState(eventName) {
+    return {
+        source: '',
+        compiled: null,
+        error: '',
+        enabled: false,
+        running: false,
+        eventName,
+        // UE lifecycle bookkeeping — populated lazily on first run.
+        handles: null,
+        beganPlay: false,
+    };
+}
+
+export function createObjectScriptState(propId = '') {
+    return {
+        propId,
+        tick: createDefaultObjectEventState('tick'),
+        collision: createDefaultObjectEventState('collision'),
+        activeCollisions: new Set(),
+    };
+}
+
+export function sanitizeObjectScriptDrafts(rawValue) {
+    if (!rawValue || typeof rawValue !== 'object') {
+        return {};
+    }
+
+    const drafts = {};
+
+    Object.entries(rawValue).forEach(([propId, value]) => {
+        if (!value || typeof value !== 'object') return;
+
+        drafts[propId] = {
+            tick: typeof value.tick === 'string' ? value.tick : '',
+            tickEnabled: value.tickEnabled === true,
+            collision: typeof value.collision === 'string' ? value.collision : '',
+        };
+    });
+
+    return drafts;
+}
+
+export function readObjectScriptDrafts() {
+    try {
+        const rawValue = window.localStorage.getItem(OBJECT_SCRIPT_STORAGE_KEY);
+        if (!rawValue) return {};
+
+        return sanitizeObjectScriptDrafts(JSON.parse(rawValue));
+    } catch (error) {
+        console.warn('Failed to load object script drafts.', error);
+        return {};
+    }
+}
+
+export function saveObjectScriptDrafts() {
+    try {
+        window.localStorage.setItem(OBJECT_SCRIPT_STORAGE_KEY, JSON.stringify(objectScriptState.drafts));
+    } catch (error) {
+        console.warn('Failed to save object script drafts.', error);
+    }
+}
+
+export function ensureObjectScriptDraftEntry(propId) {
+    if (!propId) {
+        return { tick: '', tickEnabled: false, collision: '' };
+    }
+
+    if (!objectScriptState.drafts[propId]) {
+        objectScriptState.drafts[propId] = {
+            tick: '',
+            tickEnabled: false,
+            collision: '',
+        };
+    }
+
+    return objectScriptState.drafts[propId];
+}
+
+export function syncRuntimePropIdCounter(propId) {
+    if (typeof propId !== 'string') return;
+
+    const match = /^prop-(\d+)$/.exec(propId);
+    if (!match) return;
+
+    const nextId = Number.parseInt(match[1], 10) + 1;
+    if (Number.isFinite(nextId)) {
+        objectScriptState.nextPropId = Math.max(objectScriptState.nextPropId, nextId);
+    }
+}
+
+export function createRuntimePropId() {
+    let propId = '';
+    do {
+        propId = `prop-${objectScriptState.nextPropId++}`;
+    } while (getDynamicPropById(propId));
+
+    ensureObjectScriptDraftEntry(propId);
+    return propId;
+}
+
+export function getActorScriptState(prop) {
+    return getScriptComponent(prop)?.state ?? prop?.scripts ?? null;
+}
+
+export function getActorMetadata(prop) {
+    return getMetadataComponent(prop) ?? null;
+}
+
+export function ensureActorIdentity(prop) {
+    if (!prop) return prop;
+
+    const propId = prop.id || createRuntimePropId();
+    prop.id = propId;
+    syncRuntimePropIdCounter(propId);
+    const mesh = getActorRenderObject(prop);
+    if (mesh?.userData) {
+        mesh.userData.dynamicPropId = propId;
+    }
+
+    return prop;
+}
+
+export function ensureActorScriptState(prop) {
+    if (!prop) return null;
+
+    const existingState = getActorScriptState(prop);
+    if (existingState) {
+        return existingState;
+    }
+
+    ensureActorIdentity(prop);
+    const scriptState = createObjectScriptState(prop.id);
+    ensureActorScriptComponent(prop, scriptState);
+    prop.scripts = scriptState;
+    return scriptState;
+}
+
+export function resetAllScriptLifecycleHandles() {
+    for (let i = 0; i < physics.dynamicBodies.length; i++) {
+        const prop = physics.dynamicBodies[i];
+        const state = getActorScriptState(prop);
+        if (!state) continue;
+        if (state.tick) { state.tick.beganPlay = false; }
+        if (state.collision) { state.collision.beganPlay = false; }
+    }
+}
+
+export function registerCollisionForProp(contactMap, prop, collisionKey, collision) {
+    if (!getActorScriptState(prop)?.collision?.enabled) return;
+
+    let propContacts = contactMap.get(prop.id);
+    if (!propContacts) {
+        propContacts = new Map();
+        contactMap.set(prop.id, propContacts);
+    }
+
+    propContacts.set(collisionKey, collision);
+}
+
+export function updateDynamicBodyCollisionScripts() {
+    if (!gameplay.active || !physics.dynamicBodies.length || !hasEnabledDynamicPropEvent('collision')) return;
+    const COLLISION_SPEED_THRESHOLD = 0.1;
+
+    const isBodyAwake = (prop, body) => {
+        if (!body) return true;
+
+        const physicsComponent = getPhysicsBodyComponent(prop);
+        return physicsComponent?.isAwake?.()
+            ?? (typeof physics.bodyInterface?.IsActive === 'function'
+                ? physics.bodyInterface.IsActive(body.GetID())
+                : true);
+    };
+
+    const wakeBody = (prop, body) => {
+        if (!body || isBodyAwake(prop, body)) return;
+
+        const physicsComponent = getPhysicsBodyComponent(prop);
+        physicsComponent?.activate?.();
+        if (!physicsComponent?.activate && typeof physics.bodyInterface?.ActivateBody === 'function') {
+            physics.bodyInterface.ActivateBody(body.GetID());
+        }
+    };
+
+    const getBodySpeed = (body) => {
+        if (!body) return Number.POSITIVE_INFINITY;
+        const velocity = copyJoltVector(tempVectorA, physics.bodyInterface.GetLinearVelocity(body.GetID()));
+        return velocity.length();
+    };
+
+    const targetEntries = physics.dynamicBodies
+        .flatMap((prop) => {
+            const mesh = getActorRenderObject(prop);
+            if (!mesh) return [];
+
+            return [{
+                prop,
+                mesh,
+                body: getActorBody(prop),
+                bounds: new THREE.Box3().setFromObject(mesh),
+            }];
+        });
+
+    const entries = physics.dynamicBodies
+        .flatMap((prop) => {
+            const scriptState = getActorScriptState(prop);
+            if (!scriptState?.collision?.enabled) return [];
+
+            const mesh = getActorRenderObject(prop);
+            if (!mesh) return [];
+
+            const body = getActorBody(prop);
+            if (!isBodyAwake(prop, body)) return [];
+
+            const speed = getBodySpeed(body);
+            if (speed <= COLLISION_SPEED_THRESHOLD) return [];
+
+            const bounds = new THREE.Box3().setFromObject(mesh);
+            const wakeBounds = bounds.clone();
+            if (prop.kind === 'vehicle') {
+                const wakePadding = THREE.MathUtils.clamp(speed * 0.05, 0.18, 0.75);
+                wakeBounds.expandByScalar(wakePadding);
+            }
+
+            return [{
+                prop,
+                mesh,
+                body,
+                bounds,
+                wakeBounds,
+            }];
+        });
+
+    const contactMap = new Map();
+    const processedPairs = new Set();
+
+    for (let index = 0; index < entries.length; index++) {
+        const current = entries[index];
+
+        for (let otherIndex = 0; otherIndex < targetEntries.length; otherIndex++) {
+            const other = targetEntries[otherIndex];
+            if (other.prop.id === current.prop.id) continue;
+
+            const directHit = current.bounds.intersectsBox(other.bounds);
+            const nearWakeHit = !directHit && current.wakeBounds?.intersectsBox(other.bounds);
+            if (!directHit && !nearWakeHit) continue;
+
+            if (nearWakeHit) {
+                wakeBody(other.prop, other.body);
+                continue;
+            }
+
+            const collisionKey = [current.prop.id, other.prop.id].sort().join(':');
+            if (processedPairs.has(collisionKey)) continue;
+            processedPairs.add(collisionKey);
+
+            wakeBody(other.prop, other.body);
+
+            registerCollisionForProp(contactMap, current.prop, collisionKey, {
+                type: 'prop',
+                otherProp: other.prop,
+                otherObject: other.mesh,
+                otherBody: other.body,
+            });
+
+            if (getActorScriptState(other.prop)?.collision?.enabled) {
+                registerCollisionForProp(contactMap, other.prop, collisionKey, {
+                    type: 'prop',
+                    otherProp: current.prop,
+                    otherObject: current.mesh,
+                    otherBody: current.body,
+                });
+            }
+        }
+    }
+
+    physics.dynamicBodies.forEach((prop) => {
+        const scriptState = getActorScriptState(prop);
+        const eventState = scriptState?.collision;
+        if (!eventState?.enabled) return;
+
+        const activeCollisions = scriptState.activeCollisions || new Set();
+        const nextCollisions = contactMap.get(prop.id) || new Map();
+
+        nextCollisions.forEach((collision, collisionKey) => {
+            if (!activeCollisions.has(collisionKey)) {
+                runObjectEventScript(prop, 'collision', { collision });
+            }
+        });
+
+        scriptState.activeCollisions = new Set(nextCollisions.keys());
+    });

--- a/src/vehicle/vehicleController.js
+++ b/src/vehicle/vehicleController.js
@@ -1,0 +1,572 @@
+// src/vehicle/vehicleController.js
+// Extracted from main.js (chore/main-js-shrink-2):
+//   - vehicle helpers around L1886–2153 (isDrivingVehicle … updateVehicleVisuals)
+//   - the drive sim L6867–7117 (updateVehicleGameplay)
+//
+// The visual-template factory (createDrivableCarVisual) lives in src/vehicle/visual.js;
+// the chassis FX (emitSurfaceEffects, etc.) live in vehicleFx (src/vehicle/fx.js bound
+// in main.js). Engine-audio hooks come from src/audio/vehicleEngineAudio.js.
+// Anything physics-construction-shaped (spawnDrivableCar, createDynamicPrimitiveBody)
+// stays in main.js because it depends on internal physics layer wiring.
+
+import * as THREE from 'three';
+import {
+    silenceVehicleEngineAudio,
+    updateVehicleEngineAudio,
+} from '../audio/vehicleEngineAudio.js';
+
+// Module-scope deps — populated by setupVehicleController.
+// `getWorldFloor` is a getter because the worldFloor mesh is created in init()
+// AFTER wireExtractedModules() runs (see main.js around L5200), so a snapshot
+// would capture `undefined`.
+let physics, gameplay, vehicleState, importedPropState;
+let camera;
+let VEHICLE_SETTINGS, PLAYER_SETTINGS;
+let getWorldFloor;
+let upVector, gameplayLookTarget;
+let tempVectorA, tempVectorB, tempVectorC, tempVectorD, tempVectorE;
+let tempQuaternionA;
+let copyJoltVector, copyJoltQuaternion;
+let getActorBody, getActorRenderObject;
+let emitVehicleSurfaceEffects;
+let getGroundHitAt, getGroundHeightAt;
+let updateGameplayUI, respawnPlayer;
+
+export function setupVehicleController(deps) {
+    ({
+        physics, gameplay, vehicleState, importedPropState,
+        camera,
+        VEHICLE_SETTINGS, PLAYER_SETTINGS,
+        getWorldFloor,
+        upVector, gameplayLookTarget,
+        tempVectorA, tempVectorB, tempVectorC, tempVectorD, tempVectorE,
+        tempQuaternionA,
+        copyJoltVector, copyJoltQuaternion,
+        getActorBody, getActorRenderObject,
+        emitVehicleSurfaceEffects,
+        getGroundHitAt, getGroundHeightAt,
+        updateGameplayUI, respawnPlayer,
+    } = deps);
+}
+
+export function isDrivingVehicle() {
+    return gameplay.active && !!vehicleState.activePropId;
+}
+
+export function getActiveVehicleProp() {
+    if (!vehicleState.activePropId) return null;
+
+    return physics.dynamicBodies.find((prop) => (
+        prop?.id === vehicleState.activePropId && prop.kind === 'vehicle'
+    )) ?? null;
+}
+
+export function clearActiveVehicle({ updateUi = false } = {}) {
+    const wasDriving = !!vehicleState.activePropId;
+    if (wasDriving) {
+        silenceVehicleEngineAudio();
+    }
+    vehicleState.activePropId = '';
+    vehicleState.brakeHeld = false;
+    vehicleState.tailWhipLastFrame = false;
+
+    if (!wasDriving) return;
+
+    physics.jumpQueued = false;
+    if (updateUi) {
+        updateGameplayUI();
+    }
+}
+
+export function getVehicleForward(target, quaternion, flatten = true) {
+    target.set(0, 0, -1).applyQuaternion(quaternion);
+    if (flatten) {
+        target.y = 0;
+        if (target.lengthSq() < 1e-6) {
+            target.set(0, 0, -1);
+        } else {
+            target.normalize();
+        }
+    }
+
+    return target;
+}
+
+export function positionVehicleCamera(vehiclePosition, vehicleRotation, delta) {
+    const flatForward = getVehicleForward(tempVectorB, vehicleRotation, true);
+    const chasePosition = tempVectorC
+        .copy(vehiclePosition)
+        .addScaledVector(upVector, VEHICLE_SETTINGS.followHeight)
+        .addScaledVector(flatForward, -VEHICLE_SETTINGS.followDistance);
+
+    const lookTarget = tempVectorD
+        .copy(vehiclePosition)
+        .addScaledVector(upVector, VEHICLE_SETTINGS.seatHeight)
+        .addScaledVector(flatForward, VEHICLE_SETTINGS.lookAhead);
+    const cameraLerp = 1 - Math.exp(-delta * VEHICLE_SETTINGS.cameraHorizontalSmoothing);
+    const cameraVerticalLerp = 1 - Math.exp(-delta * VEHICLE_SETTINGS.cameraVerticalSmoothing);
+    const lookLerp = 1 - Math.exp(-delta * VEHICLE_SETTINGS.cameraLookSmoothing);
+
+    camera.position.x = THREE.MathUtils.lerp(camera.position.x, chasePosition.x, cameraLerp);
+    camera.position.z = THREE.MathUtils.lerp(camera.position.z, chasePosition.z, cameraLerp);
+    camera.position.y = THREE.MathUtils.lerp(camera.position.y, chasePosition.y, cameraVerticalLerp);
+
+    gameplayLookTarget.lerp(lookTarget, lookLerp);
+    camera.lookAt(gameplayLookTarget);
+
+    tempVectorE.copy(gameplayLookTarget).sub(camera.position);
+    const flatDistance = Math.max(0.001, Math.hypot(tempVectorE.x, tempVectorE.z));
+    gameplay.yaw = Math.atan2(tempVectorE.x, tempVectorE.z);
+    gameplay.pitch = THREE.MathUtils.clamp(
+        Math.atan2(-tempVectorE.y, flatDistance),
+        -PLAYER_SETTINGS.maxLookPitch,
+        PLAYER_SETTINGS.maxLookPitch
+    );
+}
+
+export function getNearbyVehicle() {
+    const origin = gameplay.active && physics.character
+        ? copyJoltVector(tempVectorA, physics.character.GetPosition())
+        : tempVectorA.copy(camera.position);
+    let closestVehicle = null;
+    let closestDistanceSq = VEHICLE_SETTINGS.interactionRadius * VEHICLE_SETTINGS.interactionRadius;
+
+    for (const prop of physics.dynamicBodies) {
+        const body = getActorBody(prop);
+        if (!body || prop.kind !== 'vehicle') continue;
+
+        const bodyPosition = copyJoltVector(tempVectorB, physics.bodyInterface.GetPosition(body.GetID()));
+        const distanceSq = origin.distanceToSquared(bodyPosition);
+        if (distanceSq < closestDistanceSq) {
+            closestDistanceSq = distanceSq;
+            closestVehicle = prop;
+        }
+    }
+
+    return closestVehicle;
+}
+
+export function enterVehicle(prop = getNearbyVehicle()) {
+    const propBody = getActorBody(prop);
+    if (!gameplay.active || !propBody || prop.kind !== 'vehicle') return false;
+
+    vehicleState.activePropId = prop.id;
+    vehicleState.brakeHeld = false;
+    physics.jumpQueued = false;
+    gameplay.grounded = true;
+
+    const vehiclePosition = copyJoltVector(tempVectorA, physics.bodyInterface.GetPosition(propBody.GetID())).clone();
+    const vehicleRotation = copyJoltQuaternion(tempQuaternionA, physics.bodyInterface.GetRotation(propBody.GetID())).clone();
+    const flatForward = getVehicleForward(tempVectorB, vehicleRotation, true);
+    gameplayLookTarget
+        .copy(vehiclePosition)
+        .addScaledVector(upVector, VEHICLE_SETTINGS.seatHeight)
+        .addScaledVector(flatForward, VEHICLE_SETTINGS.lookAhead);
+    positionVehicleCamera(vehiclePosition, vehicleRotation, 1 / 60);
+
+    updateGameplayUI();
+    return true;
+}
+
+export function exitVehicle() {
+    const vehicle = getActiveVehicleProp();
+    const vehicleBody = getActorBody(vehicle);
+    if (!vehicleBody) {
+        clearActiveVehicle({ updateUi: true });
+        return false;
+    }
+
+    const vehiclePosition = copyJoltVector(tempVectorA, physics.bodyInterface.GetPosition(vehicleBody.GetID()));
+    const vehicleRotation = copyJoltQuaternion(tempQuaternionA, physics.bodyInterface.GetRotation(vehicleBody.GetID()));
+    const flatForward = getVehicleForward(tempVectorB, vehicleRotation, true);
+    const exitRight = tempVectorC.set(1, 0, 0).applyQuaternion(vehicleRotation);
+    exitRight.y = 0;
+    if (exitRight.lengthSq() < 1e-6) {
+        exitRight.set(1, 0, 0);
+    } else {
+        exitRight.normalize();
+    }
+
+    gameplay.spawnPoint.copy(vehiclePosition)
+        .addScaledVector(exitRight, VEHICLE_SETTINGS.width * 0.95)
+        .addScaledVector(flatForward, -0.45);
+
+    const groundHit = getGroundHitAt(gameplay.spawnPoint.x, gameplay.spawnPoint.z, true);
+    if (groundHit?.point) {
+        gameplay.spawnPoint.y = groundHit.point.y + PLAYER_SETTINGS.floorOffset;
+    }
+
+    gameplay.spawnYaw = Math.atan2(flatForward.x, flatForward.z);
+    gameplay.spawnPitch = -0.08;
+    clearActiveVehicle();
+    respawnPlayer(true);
+    return true;
+}
+
+
+export function ensureVehicleVisualState(root) {
+    if (!root) return null;
+
+    const state = root.userData?.vehicleVisual ?? null;
+    const refsValid =
+        state?.lastWorldPosition instanceof THREE.Vector3
+        && Array.isArray(state.steeringPivots)
+        && state.steeringPivots.every((p) => p?.isObject3D)
+        && Array.isArray(state.spinGroups)
+        && state.spinGroups.every((g) => g?.isObject3D);
+    if (refsValid) return state;
+
+    const steeringPivots = [];
+    const spinGroups = [];
+    root.traverse((object) => {
+        const isSteeringPivot = object.userData?.vehicleSteeringPivot === true
+            || typeof object.userData?.steerable === 'boolean';
+        if (!isSteeringPivot) return;
+
+        const spinGroup = object.children.find((child) => child.userData?.vehicleSpinGroup === true)
+            ?? object.children.find((child) => child.isGroup || child.type === 'Group');
+        if (!spinGroup) return;
+
+        steeringPivots.push(object);
+        spinGroups.push(spinGroup);
+    });
+
+    if (!steeringPivots.length || steeringPivots.length !== spinGroups.length) return null;
+
+    const nextState = {
+        steeringPivots,
+        spinGroups,
+        wheelRadius: Number.isFinite(state?.wheelRadius) ? state.wheelRadius : VEHICLE_SETTINGS.height * 0.36,
+        maxSteerAngle: Number.isFinite(state?.maxSteerAngle) ? state.maxSteerAngle : 1.0,
+        steerAngle: Number.isFinite(state?.steerAngle) ? state.steerAngle : 0,
+        spinAngle: Number.isFinite(state?.spinAngle) ? state.spinAngle : 0,
+        lastWorldPosition: new THREE.Vector3(),
+        lastPositionInitialized: false,
+    };
+    root.userData.vehicleVisual = nextState;
+    return nextState;
+}
+
+
+export function updateVehicleVisuals(delta) {
+    if (!physics.dynamicBodies?.length) return;
+
+    const { bodyInterface } = physics;
+    for (const prop of physics.dynamicBodies) {
+        const renderObject = getActorRenderObject(prop);
+        if (prop?.kind !== 'vehicle' || !renderObject) continue;
+
+        const visualState = ensureVehicleVisualState(renderObject);
+        if (!visualState) continue;
+
+        // If userData was JSON-roundtripped (e.g. via three.js Object3D.clone
+        // on a serialized template), every live reference inside vehicleVisual
+        // is now a plain object: Vector3 has no .copy, steeringPivots / spinGroups
+        // entries have no .rotation/.userData. Rather than crash every frame,
+        // skip the broken state — the wheels won't animate but the editor stays
+        // usable.
+        const refsValid =
+            visualState.lastWorldPosition instanceof THREE.Vector3
+            && Array.isArray(visualState.steeringPivots)
+            && visualState.steeringPivots.every((p) => p?.isObject3D)
+            && Array.isArray(visualState.spinGroups)
+            && visualState.spinGroups.every((g) => g?.isObject3D);
+        if (!refsValid) continue;
+
+        const flatForward = tempVectorA.set(0, 0, -1).applyQuaternion(renderObject.quaternion);
+        flatForward.y = 0;
+        if (flatForward.lengthSq() < 1e-6) {
+            flatForward.set(0, 0, -1);
+        } else {
+            flatForward.normalize();
+        }
+
+        // Prefer Jolt's authoritative velocity while physics is stepping; in
+        // edit/showcase mode physics is paused, so fall back to a frame-to-frame
+        // world-position delta so the wheels still spin when the user drags
+        // or scripts move the chassis.
+        const body = bodyInterface ? getActorBody(prop) : null;
+        let forwardSpeed = 0;
+        if (body && physics.ready && gameplay.active) {
+            const linearVelocity = copyJoltVector(tempVectorB, bodyInterface.GetLinearVelocity(body.GetID()));
+            forwardSpeed = linearVelocity.dot(flatForward);
+        } else {
+            const currentPos = renderObject.getWorldPosition(tempVectorB);
+            if (visualState.lastPositionInitialized && delta > 1e-5) {
+                const move = tempVectorC.subVectors(currentPos, visualState.lastWorldPosition);
+                forwardSpeed = move.dot(flatForward) / delta;
+            }
+            visualState.lastWorldPosition.copy(currentPos);
+            visualState.lastPositionInitialized = true;
+        }
+
+        visualState.spinAngle += (forwardSpeed / visualState.wheelRadius) * delta;
+        const isActiveVehicle = gameplay.active && vehicleState.activePropId === prop.id;
+        const inputSteer = isActiveVehicle
+            ? ((gameplay.input.left ? 1 : 0) - (gameplay.input.right ? 1 : 0))
+            : 0;
+        const speedRatio = THREE.MathUtils.clamp(Math.abs(forwardSpeed) / VEHICLE_SETTINGS.maxDriveSpeed, 0, 1);
+        const targetSteerAngle = inputSteer * visualState.maxSteerAngle * THREE.MathUtils.lerp(1, 0.58, speedRatio);
+        visualState.steerAngle = THREE.MathUtils.damp(visualState.steerAngle, targetSteerAngle, 10, delta);
+
+        visualState.steeringPivots.forEach((pivot) => {
+            pivot.rotation.y = pivot.userData.steerable ? visualState.steerAngle : 0;
+        });
+        visualState.spinGroups.forEach((group) => {
+            group.rotation.x = visualState.spinAngle;
+        });
+    }
+}
+
+export function updateVehicleGameplay(delta) {
+    const vehicle = getActiveVehicleProp();
+    if (!vehicle?.body) {
+        clearActiveVehicle({ updateUi: true });
+        return;
+    }
+
+    const { Jolt, bodyInterface } = physics;
+    const bodyId = vehicle.body.GetID();
+    const throttle = (gameplay.input.forward ? 1 : 0) - (gameplay.input.back ? 1 : 0);
+    const steer = (gameplay.input.left ? 1 : 0) - (gameplay.input.right ? 1 : 0);
+    const boostMultiplier = gameplay.input.sprint ? 1.35 : 1;
+    const vehiclePosition = copyJoltVector(tempVectorA, bodyInterface.GetPosition(bodyId)).clone();
+    const vehicleRotation = copyJoltQuaternion(tempQuaternionA, bodyInterface.GetRotation(bodyId)).clone();
+    const flatForward = getVehicleForward(tempVectorB, vehicleRotation, true).clone();
+    const vehicleUp = tempVectorC.set(0, 1, 0).applyQuaternion(vehicleRotation).normalize().clone();
+    const vehicleForward = tempVectorA.set(0, 0, -1).applyQuaternion(vehicleRotation).normalize().clone();
+    const vehicleRight = tempVectorB.set(1, 0, 0).applyQuaternion(vehicleRotation).normalize().clone();
+    const linearVelocity = copyJoltVector(tempVectorD, bodyInterface.GetLinearVelocity(bodyId)).clone();
+    const angularVelocity = copyJoltVector(tempVectorE, bodyInterface.GetAngularVelocity(bodyId)).clone();
+    const flatRight = tempVectorC.crossVectors(flatForward, upVector).normalize().clone();
+    const horizontalVelocity = tempVectorD.copy(linearVelocity).setY(0);
+    const forwardSpeed = horizontalVelocity.dot(flatForward);
+    const lateralSpeed = horizontalVelocity.dot(flatRight);
+    const throttleInput = throttle;
+    const speedRatio = THREE.MathUtils.clamp(Math.abs(forwardSpeed) / VEHICLE_SETTINGS.maxDriveSpeed, 0, 1);
+    const driftInput = Math.abs(steer) > 0.1 && speedRatio > VEHICLE_SETTINGS.driftBoostThreshold;
+    const drifting = driftInput && (throttle !== 0 || Math.abs(lateralSpeed) > 1.2);
+    const halfWheelBase = VEHICLE_SETTINGS.wheelBase * 1.0;
+    const halfTrackWidth = VEHICLE_SETTINGS.trackWidth * 0.5;
+    const rideState = vehicle.mesh.userData.vehicleRideState || {
+        sampleRideHeights: [null, null, null, null],
+        compression: 0,
+        contactRatio: 0,
+        frontCompression: 0,
+        rearCompression: 0,
+        leftCompression: 0,
+        rightCompression: 0,
+        filteredGroundHeight: null,
+    };
+    vehicle.mesh.userData.vehicleRideState = rideState;
+    const cornerSamples = [
+        { forward: halfWheelBase, sideways: -halfTrackWidth },
+        { forward: halfWheelBase, sideways: halfTrackWidth },
+        { forward: -halfWheelBase, sideways: -halfTrackWidth },
+        { forward: -halfWheelBase, sideways: halfTrackWidth },
+    ].map((corner, index) => {
+        const sampleX = vehiclePosition.x + flatForward.x * corner.forward + flatRight.x * corner.sideways;
+        const sampleZ = vehiclePosition.z + flatForward.z * corner.forward + flatRight.z * corner.sideways;
+        const sampleAnchorY = vehiclePosition.y
+            + vehicleForward.y * corner.forward
+            + vehicleRight.y * corner.sideways;
+        const groundHeight = getGroundHeightAt(sampleX, sampleZ, true, {
+            ignoreActor: vehicle,
+            minSurfaceUpDot: 0.35,
+            surfaceStepTolerance: 0,
+            cullBackFaces: true,
+            maxHitY: sampleAnchorY + 0.05,
+        });
+        const rideHeight = groundHeight === null ? null : vehiclePosition.y - groundHeight;
+        rideState.sampleRideHeights[index] = rideHeight;
+        const compression = rideHeight === null
+            ? 0
+            : THREE.MathUtils.clamp(VEHICLE_SETTINGS.suspensionRideHeight - rideHeight, 0, VEHICLE_SETTINGS.suspensionTravel);
+
+        return {
+            ...corner,
+            rideHeight,
+            compression,
+        };
+    });
+    const contactSamples = cornerSamples.filter((corner) => corner.rideHeight !== null && corner.rideHeight <= VEHICLE_SETTINGS.suspensionRideHeight + VEHICLE_SETTINGS.suspensionTravel);
+    const grounded = contactSamples.length > 0;
+    const contactRatio = contactSamples.length / cornerSamples.length;
+    const averageCompression = contactSamples.length
+        ? Math.max(...contactSamples.map((corner) => corner.compression))
+        : 0;
+    const averageGroundHeight = contactSamples.length
+        ? Math.max(...contactSamples.map((corner) => vehiclePosition.y - corner.rideHeight))
+        : null;
+    const frontCompression = Math.max(cornerSamples[0].compression, cornerSamples[1].compression);
+    const rearCompression = Math.max(cornerSamples[2].compression, cornerSamples[3].compression);
+    const leftCompression = Math.max(cornerSamples[0].compression, cornerSamples[2].compression);
+    const rightCompression = Math.max(cornerSamples[1].compression, cornerSamples[3].compression);
+    rideState.compression = averageCompression;
+    rideState.contactRatio = contactRatio;
+    rideState.frontCompression = frontCompression;
+    rideState.rearCompression = rearCompression;
+    rideState.leftCompression = leftCompression;
+    rideState.rightCompression = rightCompression;
+    const smoothedAverageCompression = averageCompression;
+    const smoothedContactRatio = contactRatio;
+    const smoothedFrontCompression = frontCompression;
+    const smoothedRearCompression = rearCompression;
+    const smoothedLeftCompression = leftCompression;
+    const smoothedRightCompression = rightCompression;
+    let filteredGroundHeight = averageGroundHeight;
+    rideState.filteredGroundHeight = filteredGroundHeight;
+    const targetForwardSpeed = grounded && throttle > 0
+        ? VEHICLE_SETTINGS.maxDriveSpeed * boostMultiplier
+        : grounded && throttle < 0
+            ? -VEHICLE_SETTINGS.maxReverseSpeed
+            : 0;
+    const forwardLambda = grounded && throttle > 0
+        ? (gameplay.input.sprint ? VEHICLE_SETTINGS.boostAcceleration : VEHICLE_SETTINGS.acceleration)
+        : grounded && throttle < 0
+            ? VEHICLE_SETTINGS.reverseAcceleration
+            : grounded
+                ? VEHICLE_SETTINGS.coastDrag
+                : 0;
+    let nextForwardSpeed = THREE.MathUtils.damp(forwardSpeed, targetForwardSpeed, forwardLambda, delta);
+    nextForwardSpeed *= 1 - (VEHICLE_SETTINGS.rollingDrag * delta);
+    const gripBase = speedRatio >= 0.5
+        ? VEHICLE_SETTINGS.highSpeedGrip
+        : VEHICLE_SETTINGS.lowSpeedGrip;
+
+    const gripLambda = vehicleState.brakeHeld
+        ? VEHICLE_SETTINGS.brakeGrip
+        : drifting
+            ? VEHICLE_SETTINGS.driftGrip
+            : gripBase;
+
+    const contactGrip = grounded
+        ? gripLambda
+        : VEHICLE_SETTINGS.partialContactGrip;
+    const nextLateralSpeed = THREE.MathUtils.damp(lateralSpeed, 0, contactGrip, delta);
+    const nextHorizontalVelocity = tempVectorE
+        .copy(flatForward)
+        .multiplyScalar(nextForwardSpeed)
+        .addScaledVector(flatRight, nextLateralSpeed);
+
+    if (vehicleState.brakeHeld) {
+        nextHorizontalVelocity.multiplyScalar(VEHICLE_SETTINGS.brakeDamping);
+    }
+
+    let nextVerticalVelocity = linearVelocity.y;
+    if (grounded && filteredGroundHeight !== null) {
+        const targetBodyHeight = filteredGroundHeight + VEHICLE_SETTINGS.suspensionRideHeight - VEHICLE_SETTINGS.suspensionTravel * 0.5;
+        const heightError = targetBodyHeight - vehiclePosition.y;
+        const springForce = heightError * VEHICLE_SETTINGS.suspensionSpring * 9.81;
+        const damperForce = -linearVelocity.y * VEHICLE_SETTINGS.suspensionDamping;
+        nextVerticalVelocity = linearVelocity.y + (springForce + damperForce) * delta;
+    }
+
+    const nextVelocity = new Jolt.Vec3(nextHorizontalVelocity.x, nextVerticalVelocity, nextHorizontalVelocity.z);
+    bodyInterface.SetLinearVelocity(bodyId, nextVelocity);
+    Jolt.destroy(nextVelocity);
+
+    const steerSpeedFactor = THREE.MathUtils.clamp(Math.abs(nextForwardSpeed) / VEHICLE_SETTINGS.maxDriveSpeed, 0, 1);
+    const steeringDirection = nextForwardSpeed >= 0 ? 1 : -0.7;
+    const steeringStrength = steerSpeedFactor >= 0.5
+        ? VEHICLE_SETTINGS.steeringHighSpeedDamping
+        : 1;
+    const driftSteerBonus = drifting ? VEHICLE_SETTINGS.driftSteerBonus : 1;
+
+    const targetYawRate = steer === 0
+        ? 0
+        : steer * steeringDirection * VEHICLE_SETTINGS.steeringRate * steeringStrength * driftSteerBonus;
+
+    const yawLambda = steer === 0 ? VEHICLE_SETTINGS.steeringReturn : VEHICLE_SETTINGS.steeringGrip;
+
+    const nextYawRate = THREE.MathUtils.damp(angularVelocity.y, targetYawRate, yawLambda, delta);
+    const rollTilt = -steer * Math.max(0.08, Math.abs(nextForwardSpeed) / VEHICLE_SETTINGS.maxDriveSpeed) * 0.5;
+    const pitchTilt = throttle === 0 ? 0 : -throttle * 0.08;
+    const nextAngular = new Jolt.Vec3(
+        THREE.MathUtils.damp(angularVelocity.x, pitchTilt, grounded ? VEHICLE_SETTINGS.pitchTorque * 0.01 : VEHICLE_SETTINGS.airtimeAngularBlend, delta),
+        nextYawRate,
+        THREE.MathUtils.damp(angularVelocity.z, rollTilt, grounded ? VEHICLE_SETTINGS.rollTorque * 0.01 : VEHICLE_SETTINGS.airtimeAngularBlend, delta)
+    );
+    bodyInterface.SetAngularVelocity(bodyId, nextAngular);
+    Jolt.destroy(nextAngular);
+
+    if (throttle !== 0 || steer !== 0 || vehicleState.brakeHeld || horizontalVelocity.lengthSq() > 0.01) {
+        bodyInterface.ActivateBody(bodyId);
+    }
+
+    const vehicleRenderObject = getActorRenderObject(vehicle);
+    const vehicleVisualState = vehicleRenderObject ? ensureVehicleVisualState(vehicleRenderObject) : null;
+    const rearWheelWorldPositions = [];
+    if (vehicleVisualState?.steeringPivots?.length >= 4) {
+        const forwardOffset = VEHICLE_SETTINGS.wheelBase * 0.18;
+        for (let i = 2; i < 4; i++) {
+            const pivot = vehicleVisualState.steeringPivots[i];
+            if (!pivot?.isObject3D) { rearWheelWorldPositions.push(null); continue; }
+            const wheelPos = new THREE.Vector3();
+            pivot.getWorldPosition(wheelPos);
+            wheelPos.y -= vehicleVisualState.wheelRadius || 0;
+            wheelPos.addScaledVector(flatForward, forwardOffset);
+            rearWheelWorldPositions.push(wheelPos);
+        }
+    }
+
+    emitVehicleSurfaceEffects(delta, {
+        vehiclePosition,
+        flatForward,
+        flatRight,
+        cornerSamples,
+        grounded,
+        drifting,
+        brakeHeld: vehicleState.brakeHeld,
+        forwardSpeed: nextForwardSpeed,
+        lateralSpeed,
+        averageCompression,
+        verticalSpeed: linearVelocity.y,
+        rearWheelWorldPositions,
+    });
+
+    const uprightCorrection = tempVectorA.copy(vehicleUp).cross(upVector).multiplyScalar(-VEHICLE_SETTINGS.uprightTorque * (grounded ? 1 : 0.05));
+    if (uprightCorrection.lengthSq() > 1e-6) {
+        const uprightTorque = new Jolt.Vec3(uprightCorrection.x, uprightCorrection.y, uprightCorrection.z);
+        bodyInterface.AddTorque(bodyId, uprightTorque, Jolt.EActivation_Activate);
+        Jolt.destroy(uprightTorque);
+    }
+
+    vehicle.mesh.position.copy(vehiclePosition);
+    vehicle.mesh.quaternion.copy(vehicleRotation);
+    updateVehicleEngineAudio(delta, vehicle, {
+        throttleInput,
+        brakeHeld: vehicleState.brakeHeld,
+        grounded,
+        forwardSpeed: nextForwardSpeed,
+    });
+    positionVehicleCamera(vehiclePosition, vehicleRotation, delta);
+    gameplay.grounded = grounded;
+    physics.jumpQueued = false;
+
+    // Update example widgets with vehicle data
+    if (window.exampleWidgets) {
+        const speedKmh = Math.round(forwardSpeed * 3.6); // Convert m/s to km/h
+        window.exampleWidgets.speed?.SetText(`Speed: ${speedKmh} km/h`);
+
+        // Update health bar based on vehicle "health" (using contact ratio as proxy)
+        window.exampleWidgets.health?.SetPercent(Math.max(0.1, smoothedContactRatio));
+
+        // Update score
+        if (window.gameScore !== undefined) {
+            // Add points for driving
+
+            // Bonus points for high speed
+            if (forwardSpeed > 15) {
+            }
+
+            window.exampleWidgets.score?.SetText(`Score: ${Math.floor(window.gameScore)}`);
+        }
+    }
+
+    const worldFloor = getWorldFloor();
+    if (worldFloor && vehiclePosition.y < worldFloor.position.y - 24) {
+        exitVehicle();
+        respawnPlayer(true);
+    }
+}

--- a/src/world/animatedSample.js
+++ b/src/world/animatedSample.js
@@ -1,0 +1,153 @@
+// src/world/animatedSample.js
+// Extracted from main.js (chore/main-js-shrink-2). Owns the procedural sample
+// model + its keyframe tracks (used by the "Load sample" button) and the
+// example HUD widget set that demos the UMG-style widget API.
+
+import * as THREE from 'three';
+
+let scene;
+let getCurrentMesh, setCurrentMesh;
+let getWidgetManager, getRuntimeHud;
+let UTextWidget, UProgressBarWidget;
+let clearCurrentMesh, normalizeCurrentMesh, refreshGameplayWorld;
+let updateLoadedAssetStats, enableOptimizationPipeline, playObjectAnimation;
+
+export function installAnimatedSample(deps) {
+    ({
+        scene,
+        getCurrentMesh, setCurrentMesh,
+        getWidgetManager, getRuntimeHud,
+        UTextWidget, UProgressBarWidget,
+        clearCurrentMesh, normalizeCurrentMesh, refreshGameplayWorld,
+        updateLoadedAssetStats, enableOptimizationPipeline, playObjectAnimation,
+    } = deps);
+}
+
+export function createExampleWidgets() {
+    if (!getWidgetManager()) return;
+
+    const hud = getRuntimeHud();
+
+    const scoreWidget = hud.CreateWidget(UTextWidget, {
+        Text: 'Score: 0',
+        fontSize: 20,
+        color: '#ffff00',
+        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+        position: { x: 0.05, y: 0.9 }, // Top-left corner
+        visible: true,
+    });
+    scoreWidget.AddToViewport(20);
+
+    const healthBar = hud.CreateWidget(UProgressBarWidget, {
+        Percent: 1.0,
+        width: 200,
+        height: 20,
+        fillColor: '#00ff00',
+        backgroundColor: '#333333',
+        position: { x: 0.05, y: 0.8 }, // Below score
+        visible: true,
+    });
+    healthBar.AddToViewport(19);
+
+    const speedWidget = hud.CreateWidget(UTextWidget, {
+        Text: 'Speed: 0 km/h',
+        fontSize: 16,
+        color: '#00ffff',
+        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+        position: { x: 0.05, y: 0.7 }, // Below health bar
+        visible: true,
+    });
+    speedWidget.AddToViewport(18);
+
+    // Store widget handles globally for easy access
+    window.exampleWidgets = {
+        score: scoreWidget,
+        health: healthBar,
+        speed: speedWidget,
+    };
+    window.gameHud = hud;
+
+    // Initialize score system
+    window.gameScore = 0;
+
+    if (window.DEBUG_WIDGET_API) {
+        console.log('Example widgets created:', window.exampleWidgets);
+        console.log('Widget API available at window.WidgetAPI');
+        console.log('Unreal widget API available at window.UnrealWidgetAPI');
+        console.log('Example usage:');
+        console.log('  WidgetAPI.createWidget("text", {text: "Hello!", position: {x: 0.5, y: 0.5}})');
+        console.log('  UnrealWidgetAPI.CreateWidget(UTextWidget, { Text: "Hello HUD" }).AddToViewport(25)');
+    }
+}
+
+export function makeAnimatedSampleQuatTrack(name, eulers) {
+    const values = [];
+    const quaternion = new THREE.Quaternion();
+    eulers.forEach(([x, y, z]) => {
+        quaternion.setFromEuler(new THREE.Euler(x, y, z));
+        values.push(quaternion.x, quaternion.y, quaternion.z, quaternion.w);
+    });
+    return new THREE.QuaternionKeyframeTrack(`${name}.quaternion`, [0, 0.5, 1.0, 1.5, 2.0], values);
+}
+
+export function makeAnimatedSamplePart(name, geometry, material, position, rotation = [0, 0, 0]) {
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.name = name;
+    mesh.position.fromArray(position);
+    mesh.rotation.set(...rotation);
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    return mesh;
+}
+
+export function createAnimatedSampleModel() {
+    const root = new THREE.Group();
+    root.name = 'PolyFlow_Animated_Test_Rig';
+
+    const chrome = new THREE.MeshStandardMaterial({ color: 0xd9f0ff, metalness: 0.45, roughness: 0.22 });
+    const teal = new THREE.MeshStandardMaterial({ color: 0x00d8ff, emissive: 0x006b80, emissiveIntensity: 0.8, metalness: 0.12, roughness: 0.3 });
+    const coral = new THREE.MeshStandardMaterial({ color: 0xff5e7a, emissive: 0x6b1022, emissiveIntensity: 0.55, metalness: 0.08, roughness: 0.36 });
+    const dark = new THREE.MeshStandardMaterial({ color: 0x182033, metalness: 0.2, roughness: 0.48 });
+    const gold = new THREE.MeshStandardMaterial({ color: 0xffd36a, emissive: 0x8a4b00, emissiveIntensity: 0.35, metalness: 0.2, roughness: 0.28 });
+
+    root.add(
+        makeAnimatedSamplePart('Rig_Base', new THREE.CylinderGeometry(0.8, 0.95, 0.08, 64), dark, [0, 0, 0]),
+        makeAnimatedSamplePart('Rig_Body', new THREE.CapsuleGeometry(0.34, 0.78, 8, 18), chrome, [0, 1.42, 0]),
+        makeAnimatedSamplePart('Rig_Chest_Core', new THREE.TorusGeometry(0.28, 0.025, 12, 48), teal, [0, 1.54, -0.31]),
+        makeAnimatedSamplePart('Rig_Head', new THREE.SphereGeometry(0.27, 32, 20), chrome, [0, 2.1, 0]),
+        makeAnimatedSamplePart('Rig_Visor', new THREE.BoxGeometry(0.38, 0.08, 0.035), teal, [0, 2.13, -0.24]),
+        makeAnimatedSamplePart('Rig_LeftArm', new THREE.CapsuleGeometry(0.08, 0.72, 6, 12), coral, [-0.5, 1.5, 0], [0, 0.2, -0.22]),
+        makeAnimatedSamplePart('Rig_RightArm', new THREE.CapsuleGeometry(0.08, 0.72, 6, 12), coral, [0.5, 1.5, 0], [0, -0.2, 0.22]),
+        makeAnimatedSamplePart('Rig_LeftLeg', new THREE.CapsuleGeometry(0.1, 0.82, 6, 12), dark, [-0.18, 0.62, 0], [0.08, 0, 0.06]),
+        makeAnimatedSamplePart('Rig_RightLeg', new THREE.CapsuleGeometry(0.1, 0.82, 6, 12), dark, [0.18, 0.62, 0], [-0.08, 0, -0.06]),
+        makeAnimatedSamplePart('Rig_Halo', new THREE.TorusGeometry(0.62, 0.018, 12, 96), gold, [0, 2.12, 0], [Math.PI / 2, 0, 0]),
+        makeAnimatedSamplePart('Rig_Energy_Ring', new THREE.TorusGeometry(0.9, 0.02, 12, 128), teal, [0, 0.06, 0], [Math.PI / 2, 0, 0])
+    );
+
+    const times = [0, 0.5, 1.0, 1.5, 2.0];
+    root.animations = [new THREE.AnimationClip('Neon_Run_Loop', 2, [
+        new THREE.VectorKeyframeTrack('Rig_Body.position', times, [0, 1.42, 0, 0, 1.56, -0.04, 0, 1.42, 0, 0, 1.56, 0.04, 0, 1.42, 0]),
+        new THREE.VectorKeyframeTrack('Rig_Head.position', times, [0, 2.1, 0, 0, 2.22, -0.03, 0, 2.1, 0, 0, 2.22, 0.03, 0, 2.1, 0]),
+        new THREE.VectorKeyframeTrack('Rig_Energy_Ring.scale', times, [1, 1, 1, 1.12, 1.12, 1.12, 1, 1, 1, 1.12, 1.12, 1.12, 1, 1, 1]),
+        makeAnimatedSampleQuatTrack('Rig_LeftArm', [[0.9, 0, -0.35], [-0.95, 0, -0.22], [0.9, 0, -0.35], [-0.95, 0, -0.22], [0.9, 0, -0.35]]),
+        makeAnimatedSampleQuatTrack('Rig_RightArm', [[-0.9, 0, 0.35], [0.95, 0, 0.22], [-0.9, 0, 0.35], [0.95, 0, 0.22], [-0.9, 0, 0.35]]),
+        makeAnimatedSampleQuatTrack('Rig_LeftLeg', [[-0.55, 0, 0.08], [0.62, 0, 0.02], [-0.55, 0, 0.08], [0.62, 0, 0.02], [-0.55, 0, 0.08]]),
+        makeAnimatedSampleQuatTrack('Rig_RightLeg', [[0.62, 0, -0.02], [-0.55, 0, -0.08], [0.62, 0, -0.02], [-0.55, 0, -0.08], [0.62, 0, -0.02]]),
+        makeAnimatedSampleQuatTrack('Rig_Halo', [[Math.PI / 2, 0, 0], [Math.PI / 2, 0, Math.PI], [Math.PI / 2, 0, Math.PI * 2], [Math.PI / 2, 0, Math.PI * 3], [Math.PI / 2, 0, Math.PI * 4]]),
+        makeAnimatedSampleQuatTrack('Rig_Energy_Ring', [[Math.PI / 2, 0, 0], [Math.PI / 2, 0, -Math.PI], [Math.PI / 2, 0, -Math.PI * 2], [Math.PI / 2, 0, -Math.PI * 3], [Math.PI / 2, 0, -Math.PI * 4]]),
+    ])];
+
+    return root;
+}
+
+export function loadSample() {
+    clearCurrentMesh();
+
+    setCurrentMesh(createAnimatedSampleModel());
+    scene.add(getCurrentMesh());
+    normalizeCurrentMesh();
+    playObjectAnimation(getCurrentMesh());
+    refreshGameplayWorld();
+    updateLoadedAssetStats('PolyFlow_Animated_Test_Rig.glb', 5400000, getCurrentMesh());
+    enableOptimizationPipeline();
+}

--- a/src/world/importedProps.js
+++ b/src/world/importedProps.js
@@ -1,0 +1,541 @@
+// src/world/importedProps.js
+// Extracted from main.js (chore/main-js-shrink-2). Owns all logic for the
+// imported-prop sidebar: collision prompts, simple/exact/convex/complex shape
+// builders, the prop library DOM rendering, registering/serializing template
+// metadata, the spawn flow, and the inline OBJ/UMAP file importer.
+//
+// Asset-loading helpers (cloneDisposableObject, loadObjectFromFile, …) come
+// through the io/objectLoader.js module — passed as deps for now to avoid
+// adding direct imports during this mechanical shrink pass.
+
+import * as THREE from 'three';
+
+let physics, importedPropState;
+let scene, camera;
+let importedPropList, importedPropLibrary;
+let propCollisionPrompt, propCollisionCopy, propCollisionRemember;
+let propImportDefaultStatus, resetPropImportDefaultBtn;
+let IMPORTED_PROP_COLLISION_LABELS, IMPORTED_PROP_COMPLEX_HULL_RADIUS;
+let IMPORTED_PROP_MAX_HULL_PARTS, IMPORTED_PROP_MAX_HULL_POINTS, PROP_TARGET_MAX_DIMENSION;
+let tempVectorA, tempVectorB, tempVectorC, tempVectorD, tempVectorE;
+let cloneDisposableObject, formatImportedPropName, normalizeObjectToDimension;
+let createLoadingManager, convertLoadedObjectMaterials, loadObjectFromFile, processTrigger;
+let createDynamicPropActor, setActorComponentFlags;
+let countTrianglesForObject;
+let createDynamicPrimitiveBody, createStaticMeshBody, createOwnedShape;
+let getDynamicPropSpawn;
+let syncActorEditorTemplateOptions, openActorEditor;
+let disposeRenderableObject, playObjectAnimation;
+let runOptimizationPipeline;
+let getResetPropImportDefault, setResetPropImportDefault;
+
+export function installImportedProps(deps) {
+    ({
+        physics, importedPropState,
+        scene, camera,
+        importedPropList, importedPropLibrary,
+        propCollisionPrompt, propCollisionCopy, propCollisionRemember,
+        propImportDefaultStatus, resetPropImportDefaultBtn,
+        IMPORTED_PROP_COLLISION_LABELS, IMPORTED_PROP_COMPLEX_HULL_RADIUS,
+        IMPORTED_PROP_MAX_HULL_PARTS, IMPORTED_PROP_MAX_HULL_POINTS, PROP_TARGET_MAX_DIMENSION,
+        tempVectorA, tempVectorB, tempVectorC, tempVectorD, tempVectorE,
+        cloneDisposableObject, formatImportedPropName, normalizeObjectToDimension,
+        createLoadingManager, convertLoadedObjectMaterials, loadObjectFromFile, processTrigger,
+        createDynamicPropActor, setActorComponentFlags,
+        countTrianglesForObject,
+        createDynamicPrimitiveBody, createStaticMeshBody, createOwnedShape,
+        getDynamicPropSpawn,
+        syncActorEditorTemplateOptions, openActorEditor,
+        disposeRenderableObject, playObjectAnimation,
+        runOptimizationPipeline,
+        getResetPropImportDefault, setResetPropImportDefault,
+    } = deps);
+}
+
+export function enableOptimizationPipeline() {
+    if (!processTrigger) return;
+    processTrigger.style.opacity = '1';
+    processTrigger.style.cursor = 'pointer';
+    processTrigger.onclick = runOptimizationPipeline;
+}
+
+export function updateLoadedAssetStats(name, fileSize, root) {
+    document.getElementById('asset-name').textContent = name;
+    document.getElementById('tri-count').textContent = 'Counting...';
+
+    originalFileSize = fileSize;
+    document.getElementById('file-size').textContent = (originalFileSize / (1024 * 1024)).toFixed(1) + ' MB';
+    document.getElementById('file-diff').textContent = '';
+    document.getElementById('webgpu-speedup').textContent = '--';
+
+    originalTriCount = Math.round(countTrianglesForObject(root));
+    console.log('Model loaded. Triangles:', originalTriCount);
+
+    const countObj = { val: 0 };
+    gsap.to(countObj, {
+        val: originalTriCount,
+        duration: 1.5,
+        ease: 'power2.out',
+        onUpdate: () => {
+            document.getElementById('tri-count').textContent = Math.ceil(countObj.val).toLocaleString();
+        },
+    });
+
+    enableOptimizationPipeline();
+}
+
+export function updatePropImportStatus() {
+    if (!propImportDefaultStatus || !resetPropImportDefaultBtn) return;
+
+    if (importedPropState.futureCollisionMode) {
+        propImportDefaultStatus.textContent = `Create actor instances with render, collision, and script components. Future imported actor sources use ${IMPORTED_PROP_COLLISION_LABELS[importedPropState.futureCollisionMode]}.`;
+        resetPropImportDefaultBtn.hidden = false;
+        return;
+    }
+
+    propImportDefaultStatus.textContent = 'Create actor instances with render, collision, and script components. Imported actor sources ask for a collision mode.';
+    resetPropImportDefaultBtn.hidden = true;
+}
+
+export function closePropCollisionPrompt() {
+    if (!propCollisionPrompt) return;
+
+    propCollisionPrompt.hidden = true;
+    if (propCollisionRemember) {
+        propCollisionRemember.checked = false;
+    }
+}
+
+export function resolvePropCollisionPrompt(selection) {
+    if (!importedPropState.promptResolver) return;
+
+    const resolver = importedPropState.promptResolver;
+    importedPropState.promptResolver = null;
+    closePropCollisionPrompt();
+    resolver(selection);
+}
+
+export function promptImportedPropCollision(fileName, triangleCount) {
+    if (importedPropState.futureCollisionMode) {
+        return Promise.resolve({
+            mode: importedPropState.futureCollisionMode,
+            remember: true,
+        });
+    }
+
+    if (!propCollisionPrompt || !propCollisionCopy) {
+        return Promise.resolve({ mode: 'complex', remember: false });
+    }
+
+    propCollisionCopy.textContent = `${formatImportedPropName(fileName)} has about ${triangleCount.toLocaleString()} triangles. Pick a simple box collision or a tighter convex collision for this imported prop.`;
+    propCollisionRemember.checked = false;
+    propCollisionPrompt.hidden = false;
+
+    return new Promise((resolve) => {
+        importedPropState.promptResolver = resolve;
+    });
+}
+
+export function createImportedSimpleShape(root) {
+    const { Jolt } = physics;
+    root.updateWorldMatrix(true, true);
+
+    const box = new THREE.Box3().setFromObject(root);
+    const size = box.getSize(tempVectorA);
+    const halfExtentVector = new Jolt.Vec3(
+        Math.max(size.x * 0.5, 0.08),
+        Math.max(size.y * 0.5, 0.08),
+        Math.max(size.z * 0.5, 0.08)
+    );
+    const shape = createOwnedShape(new Jolt.BoxShapeSettings(halfExtentVector, 0.03));
+    Jolt.destroy(halfExtentVector);
+    return shape;
+}
+
+export function createExactMeshShape(root) {
+    if (!physics.ready || !root) return null;
+
+    const { Jolt } = physics;
+    root.updateWorldMatrix(true, true);
+
+    const totalTriangles = countTrianglesForObject(root);
+    if (!totalTriangles) {
+        throw new Error('Imported prop has no usable mesh geometry for exact collision.');
+    }
+
+    const triangles = new Jolt.TriangleList();
+    const materials = new Jolt.PhysicsMaterialList();
+    const rootInverse = new THREE.Matrix4().copy(root.matrixWorld).invert();
+    const childToRoot = new THREE.Matrix4();
+
+    triangles.resize(totalTriangles);
+    let triangleIndex = 0;
+
+    try {
+        root.traverse((child) => {
+            if (!child.isMesh || !child.geometry?.attributes?.position) return;
+
+            const position = child.geometry.getAttribute('position');
+            const index = child.geometry.getIndex();
+            const triangleCount = index ? index.count / 3 : position.count / 3;
+
+            childToRoot.multiplyMatrices(rootInverse, child.matrixWorld);
+
+            for (let triangleOffset = 0; triangleOffset < triangleCount; triangleOffset++) {
+                const i0 = index ? index.getX(triangleOffset * 3) : triangleOffset * 3;
+                const i1 = index ? index.getX(triangleOffset * 3 + 1) : triangleOffset * 3 + 1;
+                const i2 = index ? index.getX(triangleOffset * 3 + 2) : triangleOffset * 3 + 2;
+
+                tempVectorA.fromBufferAttribute(position, i0).applyMatrix4(childToRoot);
+                tempVectorB.fromBufferAttribute(position, i1).applyMatrix4(childToRoot);
+                tempVectorC.fromBufferAttribute(position, i2).applyMatrix4(childToRoot);
+
+                const triangle = triangles.at(triangleIndex++);
+                const v1 = triangle.get_mV(0);
+                const v2 = triangle.get_mV(1);
+                const v3 = triangle.get_mV(2);
+                v1.x = tempVectorA.x;
+                v1.y = tempVectorA.y;
+                v1.z = tempVectorA.z;
+                v2.x = tempVectorB.x;
+                v2.y = tempVectorB.y;
+                v2.z = tempVectorB.z;
+                v3.x = tempVectorC.x;
+                v3.y = tempVectorC.y;
+                v3.z = tempVectorC.z;
+            }
+        });
+
+        return createOwnedShape(new Jolt.MeshShapeSettings(triangles, materials));
+    } finally {
+        Jolt.destroy(triangles);
+        Jolt.destroy(materials);
+    }
+}
+
+export function createImportedConvexHullShape(points) {
+    const { Jolt } = physics;
+    const settings = new Jolt.ConvexHullShapeSettings();
+    settings.mPoints = points;
+    settings.mMaxConvexRadius = IMPORTED_PROP_COMPLEX_HULL_RADIUS;
+    settings.mMaxErrorConvexRadius = IMPORTED_PROP_COMPLEX_HULL_RADIUS;
+    return createOwnedShape(settings);
+}
+
+export function collectImportedComplexHullParts(root) {
+    const rootInverse = new THREE.Matrix4().copy(root.matrixWorld).invert();
+    const childToRoot = new THREE.Matrix4();
+    const hullParts = [];
+
+    root.traverse((child) => {
+        if (!child.isMesh || !child.geometry?.attributes?.position) return;
+
+        const position = child.geometry.getAttribute('position');
+        if (!position || position.count < 4) return;
+
+        const sampleStep = Math.max(1, Math.ceil(position.count / IMPORTED_PROP_MAX_HULL_POINTS));
+        const points = [];
+        childToRoot.multiplyMatrices(rootInverse, child.matrixWorld);
+
+        for (let i = 0; i < position.count; i += sampleStep) {
+            tempVectorA.fromBufferAttribute(position, i).applyMatrix4(childToRoot);
+            points.push({
+                x: tempVectorA.x,
+                y: tempVectorA.y,
+                z: tempVectorA.z,
+            });
+        }
+
+        if (points.length < 4) return;
+
+        hullParts.push({
+            points,
+            weight: points.length,
+        });
+    });
+
+    if (hullParts.length <= IMPORTED_PROP_MAX_HULL_PARTS) {
+        return hullParts;
+    }
+
+    return hullParts
+        .sort((left, right) => right.weight - left.weight)
+        .slice(0, IMPORTED_PROP_MAX_HULL_PARTS);
+}
+
+export function createImportedComplexShape(root) {
+    return createExactMeshShape(root);
+}
+
+export function createImportedCollisionShape(root, mode) {
+    if (mode === 'simple') {
+        return { shape: createImportedSimpleShape(root), mode: 'simple' };
+    }
+
+    try {
+        return { shape: createImportedComplexShape(root), mode: 'complex' };
+    } catch (error) {
+        console.warn('Falling back to simple imported collision shape.', error);
+        alert('Complex collision was not valid for this prop. Falling back to simple collision for this import.');
+        return { shape: createImportedSimpleShape(root), mode: 'simple' };
+    }
+}
+
+export function renderImportedPropButtons() {
+    if (!importedPropList || !importedPropLibrary) return;
+
+    importedPropList.innerHTML = '';
+    importedPropLibrary.hidden = importedPropState.templates.length === 0;
+
+    importedPropState.templates.forEach((template) => {
+        const button = document.createElement('button');
+        button.className = 'btn viewer-menu-btn';
+        button.textContent = `${template.displayName} · ${template.collisionMode === 'simple' ? 'Simple' : 'Complex'}`;
+        button.title = `Open the actor editor for ${template.displayName} with ${IMPORTED_PROP_COLLISION_LABELS[template.collisionMode]}.`;
+        button.addEventListener('click', () => openActorEditor({ kind: 'imported', templateId: template.id, label: template.displayName }));
+        importedPropList.appendChild(button);
+    });
+
+    syncActorEditorTemplateOptions();
+}
+
+export function registerImportedPropTemplate(fileName, root, collisionMode, shape, triangleCount) {
+    const displayName = formatImportedPropName(fileName);
+    const template = {
+        id: `imported-prop-${importedPropState.nextId++}`,
+        fileName,
+        displayName,
+        root,
+        shape,
+        collisionMode,
+        triangleCount,
+    };
+
+    importedPropState.templates.push(template);
+    renderImportedPropButtons();
+    updatePropImportStatus();
+    return template;
+}
+
+export async function registerImportedPropTemplateFromSerializedData(templateData, { fileMap = null } = {}) {
+    if (!templateData) return null;
+
+    const existingTemplate = importedPropState.templates.find((entry) => entry.id === templateData.id);
+    if (existingTemplate) {
+        return existingTemplate;
+    }
+
+    let root = null;
+
+    // Folder-bundle path: the .umap stores assetPath instead of rootJson and
+    // the raw OBJ/GLB lives next to it. Resolve via the loaded fileMap and
+    // run the same importer the fresh-import flow uses — much faster than
+    // re-hydrating a THREE.ObjectLoader JSON blob.
+    if (templateData.assetPath && fileMap) {
+        const entry = lookupBundleAsset(fileMap, templateData.assetPath, templateData.fileName);
+        if (entry?.file) {
+            root = await loadObjectFromFile(entry.file, fileMap);
+            if (templateData.assetType !== 'glb') {
+                normalizeObjectToDimension(root, PROP_TARGET_MAX_DIMENSION, false);
+            }
+        } else {
+            console.warn(`[scene] Asset "${templateData.assetPath}" missing from bundle; template will be skipped.`);
+            return null;
+        }
+    } else if (templateData.rootJson) {
+        const objectLoader = new THREE.ObjectLoader();
+        root = objectLoader.parse(templateData.rootJson);
+        convertLoadedObjectMaterials(root);
+        // Legacy serialized templates already carried the normalized transform
+        // applied at import time. Re-normalizing here mutates the source asset
+        // before any actor transform is restored.
+        if (templateData.normalized === false) {
+            normalizeObjectToDimension(root, PROP_TARGET_MAX_DIMENSION, false);
+        }
+    } else {
+        return null;
+    }
+
+    const triangleCount = Number.isFinite(templateData.triangleCount)
+        ? templateData.triangleCount
+        : Math.round(countTrianglesForObject(root));
+    const collision = createImportedCollisionShape(root, templateData.collisionMode || 'simple');
+    const template = {
+        id: templateData.id || `imported-prop-${importedPropState.nextId++}`,
+        fileName: templateData.fileName || 'Imported Prop',
+        displayName: templateData.displayName || formatImportedPropName(templateData.fileName || 'Imported Prop'),
+        root,
+        shape: collision.shape,
+        collisionMode: collision.mode,
+        triangleCount,
+    };
+
+    importedPropState.templates.push(template);
+
+    // If we loaded from a folder bundle, retain the original File so the user
+    // can re-save the scene as a folder without re-inlining the geometry.
+    if (templateData.assetPath && fileMap) {
+        const entry = lookupBundleAsset(fileMap, templateData.assetPath, templateData.fileName);
+        if (entry?.file) {
+            importedPropState.sourceFiles[template.id] = entry.file;
+        }
+    }
+
+    const matchedId = /imported-prop-(\d+)$/.exec(template.id || '');
+    if (matchedId) {
+        importedPropState.nextId = Math.max(importedPropState.nextId, Number(matchedId[1]) + 1);
+    }
+
+    renderImportedPropButtons();
+    updatePropImportStatus();
+    return template;
+}
+
+export function lookupBundleAsset(fileMap, assetPath, fileName) {
+    if (!fileMap) return null;
+    // fileMap is the same shape used by setupDropHandlers / createLoadingManager:
+    // { 'relative/path.ext': { file, url } } and/or { 'basename.ext': { file, url } }.
+    return fileMap[assetPath]
+        || (fileName ? fileMap[fileName] : null)
+        || (fileName ? fileMap[fileName.toLowerCase()] : null)
+        || null;
+}
+
+export function serializeImportedPropTemplate(template, { preferAssetPath = false } = {}) {
+    if (!template?.root) return null;
+
+    const base = {
+        id: template.id,
+        fileName: template.fileName,
+        displayName: template.displayName,
+        normalized: true,
+        collisionMode: template.collisionMode,
+        triangleCount: template.triangleCount,
+    };
+
+    // When a scene is being saved as a folder bundle and we still have the
+    // original imported File, point at it via assetPath. Bundle loading then
+    // re-runs the OBJ/GLB importer on the raw file (fast) instead of parsing
+    // a serialized THREE.ObjectLoader blob (slow). Inline rootJson stays as
+    // the fallback for templates whose source file isn't available.
+    const sourceFile = importedPropState.sourceFiles?.[template.id];
+    if (preferAssetPath && sourceFile) {
+        return { ...base, assetPath: `assets/${template.fileName}` };
+    }
+
+    return { ...base, rootJson: template.root.toJSON() };
+}
+
+export function spawnImportedProp(templateId, options = {}) {
+    if (!physics.ready || !scene || !camera) {
+        console.warn('Jolt physics is not ready yet.');
+        return null;
+    }
+
+    const template = importedPropState.templates.find((entry) => entry.id === templateId);
+    if (!template?.root) return null;
+
+    const spawnPosition = tempVectorD;
+    const launchImpulse = tempVectorE;
+    getDynamicPropSpawn(spawnPosition, launchImpulse);
+
+    const visual = cloneDisposableObject(template.root);
+    let body = null;
+    const includeCollisionBody = options.includeCollisionBody !== false;
+    const requestedSimulatePhysics = includeCollisionBody && options.simulatePhysics !== false;
+    const useExactMeshCollision = template.collisionMode === 'complex';
+    const simulatePhysics = requestedSimulatePhysics && !useExactMeshCollision;
+
+    if (includeCollisionBody && useExactMeshCollision && requestedSimulatePhysics) {
+        console.warn('Exact triangle mesh collision is static-only; spawning imported prop without simulated physics.');
+    }
+
+    visual.position.copy(spawnPosition);
+
+    if (includeCollisionBody) {
+        if (useExactMeshCollision) {
+            body = createStaticMeshBody(visual);
+        } else {
+            template.shape.AddRef();
+
+            body = createDynamicPrimitiveBody(
+                template.shape,
+                spawnPosition,
+                launchImpulse,
+                {
+                    ...(template.collisionMode === 'simple'
+                        ? { restitution: 0.12, friction: 0.84 }
+                        : { restitution: 0.08, friction: 0.76 }),
+                    simulatePhysics,
+                }
+            );
+        }
+
+        if (!body) {
+            disposeRenderableObject(visual);
+            return null;
+        }
+    }
+
+    const actor = createDynamicPropActor({
+        body,
+        mesh: visual,
+        kind: 'imported',
+        templateId,
+        userData: options.userData,
+        includeScripts: options.includeScripts !== false,
+    });
+    setActorComponentFlags(actor, {
+        collision: !!body,
+        physics: !!body && simulatePhysics,
+        scripts: options.includeScripts !== false,
+    });
+    if (body) {
+        if (simulatePhysics) {
+            physics.dynamicBodies.push(actor);
+        } else {
+            physics.staticBodies.push(actor);
+        }
+    }
+    playObjectAnimation(visual);
+    return actor;
+}
+
+export async function importPhysicsProp(file, fileMap = {}) {
+    if (!file) return;
+
+    try {
+        const root = await loadObjectFromFile(file, fileMap);
+        normalizeObjectToDimension(root, PROP_TARGET_MAX_DIMENSION, false);
+        const triangleCount = Math.round(countTrianglesForObject(root));
+
+        if (!triangleCount) {
+            disposeRenderableObject(root);
+            alert('Imported prop has no usable mesh geometry.');
+            return;
+        }
+
+        const collisionPreference = await promptImportedPropCollision(file.name, triangleCount);
+        if (!collisionPreference) {
+            disposeRenderableObject(root);
+            return;
+        }
+
+        if (collisionPreference.remember) {
+            importedPropState.futureCollisionMode = collisionPreference.mode;
+        }
+
+        const collision = createImportedCollisionShape(root, collisionPreference.mode);
+        const template = registerImportedPropTemplate(file.name, root, collision.mode, collision.shape, triangleCount);
+        if (template?.id && file instanceof File) {
+            importedPropState.sourceFiles[template.id] = file;
+        }
+        updatePropImportStatus();
+        return template;
+    } catch (error) {
+        console.error('Failed to import physics prop.', error);
+        alert(error?.message === 'Unsupported file format'
+            ? 'Unsupported file format for physics prop import.'
+            : 'Failed to import the selected prop. Check the console for details.');
+    }
+}


### PR DESCRIPTION
## ⚠️ Branch is incomplete — `main.js` not yet pushed

This PR is **draft** and **not buildable** from `origin/chore/main-js-shrink-2` alone. The 11 new module files pushed here are correct (verified byte-for-byte against local), but `main.js` itself is still missing from the branch — the file is 143 KB which is past the inline-content limit of the tool I used to push from a sandbox.

To finish before merging, apply the local patch / tarball over this branch and push:

```bash
git fetch origin chore/main-js-shrink-2
git checkout chore/main-js-shrink-2
# Drop in main.js from the locally-saved tarball (or apply main-js-shrink-2.patch)
tar -xzf main-js-shrink-2.tar.gz main.js
git add main.js
git commit -m "shrink root main.js: extract 11 modules (314.6 KB -> 143.3 KB)"
git push origin chore/main-js-shrink-2
```

Once `main.js` is on the branch, mark this PR ready for review, run `npm run dev`, click around (drive a car, drop a model, edit terrain, exit gameplay), and merge.

## What this branch does

Extracts cohesive function groups out of root `main.js` into 11 separate ES modules under `src/`. Same wiring pattern as the prior `chore/main-js-shrink` branch: each new module declares `let dep1, dep2, …;` at module scope, exports an `installXxx(deps)` setter that destructures into those bindings, and exports the original function names so call sites in `main.js` stay identical. `main.js` gains an `installXxx({…})` call inside `wireExtractedModules()` for every new module.

### New modules

| Module | KB | Scope |
|---|---:|---|
| `src/gameplay/gameplayLoop.js` | 41 | play-mode loop, showcase free-fly camera, gameplay/showcase keyboard+mouse handlers, gameplay UI |
| `src/editor/sceneUi.js` | 37 | post-process / actor / world env / scene list UI |
| `src/vehicle/vehicleController.js` | 25 | drive sim + chase camera + vehicle state |
| `src/world/importedProps.js` | 21 | imported-prop sidebar, collision shapes, library DOM, OBJ/UMAP file importer |
| `src/debug/sceneDebug.js` | 17 | raycast / collision overlays / shadow / perf-mode (DDGI / bloom / fog suspend) |
| `src/physics/actorPhysics.js` | 15 | `rebuildActorPhysics` + per-actor previews + transform↔body sync |
| `src/editor/terrainPanel.js` | 14 | brush helper, paint, terrain DOM panel |
| `src/optim/sceneExport.js` | 13 | GLTFExporter + meshopt simplification + folder export |
| `src/scripting/scriptState.js` | 12 | script drafts + `updateDynamicBodyCollisionScripts` |
| `src/io/dropHandlers.js` | 8 | file-drop / dropdown loader, scan effect, `onWindowResize` |
| `src/world/animatedSample.js` | 7 | procedural sample model + example HUD widgets |

### Late-init refs

`worldFloor`, `mainDirectionalLight`, `currentMesh`, `ambientLight`, `hemiLight`, `ddgiVolume`, `volumetricFogController`, `environmentController`, `grassField`, `scanPlane`, `modelBody`, `widgetManager`, `pedestal`, `resetViewBtn`, `gameplayStatus`, `playHint`, `sceneUiList` — all assigned in `init()` AFTER `wireExtractedModules()` runs. They come through as `getXxx() / setXxx(v)` callbacks instead of snapshot values so the modules see the live engine state.

### Bugs caught + fixed during the push pass

1. `let perfModeEnabled = false;` was missing in `src/debug/sceneDebug.js` — it was a top-level `let` in main.js that the extraction missed. Without it, `setPerfModeEnabled` would throw.
2. In `src/editor/sceneUi.js` `spawnActorFromEditor()`, the string literal `'ddgiVolume'` was rewritten to `'getDdgiVolume()'` by the getter-substitution regex during extraction. Caught on visual diff. Fixed in the tarball + patch.

### Validation

- All 11 modules pass `node --check`.
- `main.js` (locally) passes `node --check`.
- Vite build / browser smoke test still pending — recommended before merge.

### Stats

- main.js: **314,610 → 143,322 bytes** (-171,288 / -54.4 %)
- 12 commits.
- No logic changes — pure mechanical move (function bodies extracted verbatim; getter rewrite for late-init refs).